### PR TITLE
fix: correct release asset upload and project date-closed workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,11 @@ jobs:
           zip -r cortex-${{ needs.release-please.outputs.tag_name }}.zip cortex/
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: |
-            main.js
-            manifest.json
-            styles.css
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.release-please.outputs.tag_name }} \
+            main.js \
+            manifest.json \
+            styles.css \
             dist/cortex-${{ needs.release-please.outputs.tag_name }}.zip

--- a/.github/workflows/set-date-closed.yml
+++ b/.github/workflows/set-date-closed.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const projectId = "PVT_kwHOA6hlQs4BSP69";
             const fieldId = "PVTF_lAHOA6hlQs4BSP69zhAYLKw";


### PR DESCRIPTION
## Summary

- **Release workflow:** Replace `softprops/action-gh-release` with `gh release upload` so assets are attached to the release-please release without overwriting the custom header/footer release body
- **set-date-closed workflow:** Switch from `GITHUB_TOKEN` to `PROJECT_TOKEN` PAT, since `GITHUB_TOKEN` cannot access GitHub Projects V2 (requires a PAT with `project` scope)

## Prerequisites
- A classic PAT with `project` scope must be stored as a repository secret named `PROJECT_TOKEN` (already added)

https://claude.ai/code/session_01Qk3akcm7qNxWyCgi9gn8pE