### PR TITLE
fix: correct stale log path comment in LoggerConfig (#75)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -7,7 +7,7 @@ let verbosity: 'normal' | 'verbose' = 'normal';
 
 export interface LoggerConfig {
   enabled: boolean;
-  /** Vault-relative path, e.g. "_cortex-debug.log" */
+  /** Vault-relative path, e.g. ".obsidian/plugins/cortex/cortex-debug.log" */
   filePath: string;
   verbosity: 'normal' | 'verbose';
 }


### PR DESCRIPTION
## Summary

- Fixes stale JSDoc comment in `LoggerConfig.filePath` — still referenced the old vault-root path `_cortex-debug.log` instead of the current `.obsidian/plugins/cortex/cortex-debug.log`
- Closes #75

## Test plan

- [ ] Merge and confirm release-please proposes 1.4.3 (not 2.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)