### PR TITLE
feat(ui): slide-in confirmation panel before session compression

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -86,6 +86,7 @@ export class ClaudeView extends ItemView {
   private atDropdownItems: TFile[] = [];
   private tokenGaugeEl: SVGElement;
   private attachPopoverEl: HTMLElement;
+  private compactConfirmEl: HTMLElement;
   private sessionContextTokens = 0;
   static readonly CONTEXT_WINDOW = 200_000;
   private atDropdownIndex = -1;
@@ -203,7 +204,7 @@ export class ClaudeView extends ItemView {
     arc.setAttribute('stroke-dasharray', String(C));
     arc.setAttribute('stroke-dashoffset', String(C));
     svg.appendChild(track); svg.appendChild(arc);
-    svg.addEventListener('click', () => this.compactSession());
+    svg.addEventListener('click', () => this.showCompactConfirm());
     svg.style.display = 'none';
     inputToolbar.appendChild(svg);
     this.tokenGaugeEl = svg;
@@ -293,6 +294,18 @@ export class ClaudeView extends ItemView {
       e.preventDefault();
       void this.handleDroppedFiles(e.dataTransfer.files);
     });
+
+    // Compact-session confirmation panel (slide-in from right)
+    this.compactConfirmEl = root.createDiv({ cls: 'obsidibot-compact-confirm' });
+    this.compactConfirmEl.createEl('p', {
+      text: 'Compact this session? Earlier messages will be summarized to free up context.',
+      cls: 'obsidibot-compact-confirm-msg',
+    });
+    const confirmBtnRow = this.compactConfirmEl.createDiv({ cls: 'obsidibot-compact-confirm-btns' });
+    const doCompactBtn = confirmBtnRow.createEl('button', { text: 'Compact', cls: 'mod-cta obsidibot-compact-confirm-btn' });
+    doCompactBtn.addEventListener('click', () => { this.hideCompactConfirm(); this.compactSession(); });
+    const cancelCompactBtn = confirmBtnRow.createEl('button', { text: 'Cancel', cls: 'obsidibot-compact-confirm-btn' });
+    cancelCompactBtn.addEventListener('click', () => this.hideCompactConfirm());
 
     // If Claude binary is missing, show setup guide and stop here
     if (!this.plugin.claudeBinaryPath) {
@@ -1344,6 +1357,18 @@ export class ClaudeView extends ItemView {
     this.tokenGaugeEl.setAttribute('aria-label', label);
     const titleEl = this.tokenGaugeEl.querySelector('title');
     if (titleEl) titleEl.textContent = label;
+  }
+
+  private showCompactConfirm() {
+    if (!this.currentSessionId) {
+      new Notice('ObsidiBot: no active session to compact.');
+      return;
+    }
+    this.compactConfirmEl.classList.add('is-visible');
+  }
+
+  private hideCompactConfirm() {
+    this.compactConfirmEl.classList.remove('is-visible');
   }
 
   private compactSession() {

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -295,8 +295,8 @@ export class ClaudeView extends ItemView {
       void this.handleDroppedFiles(e.dataTransfer.files);
     });
 
-    // Compact-session confirmation panel (slide-in from right)
-    this.compactConfirmEl = root.createDiv({ cls: 'obsidibot-compact-confirm' });
+    // Compact-session confirmation panel (slide-in from right, anchored above input area)
+    this.compactConfirmEl = inputArea.createDiv({ cls: 'obsidibot-compact-confirm' });
     this.compactConfirmEl.createEl('p', {
       text: 'Compact this session? Earlier messages will be summarized to free up context.',
       cls: 'obsidibot-compact-confirm-msg',

--- a/styles.css
+++ b/styles.css
@@ -42,6 +42,7 @@
   flex-direction: column;
   border-top: 1px solid var(--background-modifier-border);
   flex-shrink: 0;
+  position: relative;
 }
 
 .obsidibot-input {
@@ -982,20 +983,14 @@
 }
 
 /* ── Compact-session confirmation panel ── */
-.obsidibot-view {
-  position: relative;
-}
-
 .obsidibot-compact-confirm {
   position: absolute;
   right: 0;
-  bottom: 0;
+  bottom: 100%;
   width: min(280px, 92%);
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
-  border-right: none;
-  border-bottom: none;
-  border-radius: 6px 0 0 0;
+  border-radius: 6px 0 6px 6px;
   padding: 12px 14px;
   box-shadow: -4px -4px 16px rgba(0, 0, 0, 0.15);
   z-index: 50;

--- a/styles.css
+++ b/styles.css
@@ -980,3 +980,47 @@
   color: var(--text-faint);
   font-style: italic;
 }
+
+/* ── Compact-session confirmation panel ── */
+.obsidibot-view {
+  position: relative;
+}
+
+.obsidibot-compact-confirm {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: min(280px, 92%);
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-right: none;
+  border-bottom: none;
+  border-radius: 6px 0 0 0;
+  padding: 12px 14px;
+  box-shadow: -4px -4px 16px rgba(0, 0, 0, 0.15);
+  z-index: 50;
+  transform: translateX(110%);
+  transition: transform 220ms ease;
+}
+
+.obsidibot-compact-confirm.is-visible {
+  transform: translateX(0);
+}
+
+.obsidibot-compact-confirm-msg {
+  margin: 0 0 10px;
+  font-size: 0.88em;
+  color: var(--text-normal);
+  line-height: 1.4;
+}
+
+.obsidibot-compact-confirm-btns {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.obsidibot-compact-confirm-btn {
+  font-size: 0.85em;
+  padding: 4px 10px;
+}

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -634,7 +634,6 @@ describe('export button disabled state', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
 // ExportToVaultModal — openAfter checkbox logic
 // ---------------------------------------------------------------------------
 
@@ -670,5 +669,68 @@ describe('ExportToVaultModal openAfter', () => {
     const r = simulateConfirm('  sessions/Note.md  ', true);
     assert.ok(r);
     assert.equal(r!.path, 'sessions/Note.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compact-confirm panel — show/hide logic
+// ---------------------------------------------------------------------------
+
+describe('compact confirm panel', () => {
+  /** Minimal panel state mirroring showCompactConfirm / hideCompactConfirm. */
+  function makePanel(sessionId: string | undefined) {
+    const classes = new Set<string>();
+    const panelEl = {
+      classList: {
+        add: (c: string) => classes.add(c),
+        remove: (c: string) => classes.delete(c),
+        has: (c: string) => classes.has(c),
+      },
+    };
+
+    function showCompactConfirm() {
+      if (!sessionId) return 'no-session';
+      panelEl.classList.add('is-visible');
+      return 'shown';
+    }
+
+    function hideCompactConfirm() {
+      panelEl.classList.remove('is-visible');
+    }
+
+    return { panelEl, showCompactConfirm, hideCompactConfirm };
+  }
+
+  test('panel is hidden by default (no is-visible class)', () => {
+    const { panelEl } = makePanel('sess-1');
+    assert.equal(panelEl.classList.has('is-visible'), false);
+  });
+
+  test('show adds is-visible when session exists', () => {
+    const { panelEl, showCompactConfirm } = makePanel('sess-1');
+    const result = showCompactConfirm();
+    assert.equal(result, 'shown');
+    assert.equal(panelEl.classList.has('is-visible'), true);
+  });
+
+  test('show does nothing when no session', () => {
+    const { panelEl, showCompactConfirm } = makePanel(undefined);
+    const result = showCompactConfirm();
+    assert.equal(result, 'no-session');
+    assert.equal(panelEl.classList.has('is-visible'), false);
+  });
+
+  test('hide removes is-visible', () => {
+    const { panelEl, showCompactConfirm, hideCompactConfirm } = makePanel('sess-1');
+    showCompactConfirm();
+    assert.equal(panelEl.classList.has('is-visible'), true);
+    hideCompactConfirm();
+    assert.equal(panelEl.classList.has('is-visible'), false);
+  });
+
+  test('hide is safe to call when panel is already hidden', () => {
+    const { panelEl, hideCompactConfirm } = makePanel('sess-1');
+    assert.doesNotThrow(() => hideCompactConfirm());
+    assert.equal(panelEl.classList.has('is-visible'), false);
   });
 });


### PR DESCRIPTION
## Summary
Clicking the context gas gauge now shows a small confirmation panel that slides in from the bottom-right corner of the chat view, rather than immediately triggering `/compact`. The panel has **Compact** and **Cancel** buttons. This prevents accidental session compression from a misclick.

## Issue
Closes #95

## Testing

1. Open Obsidian with a test vault that has ObsidiBot enabled.
2. Send several messages until the context gauge ring becomes visible in the input toolbar.
3. Click the gas gauge ring.
   - Expected: a confirmation panel slides in from the bottom-right corner with a brief description and **Compact** / **Cancel** buttons. `/compact` does NOT fire immediately.
4. Click **Cancel**.
   - Expected: panel slides out (or disappears), session is unchanged.
5. Click the gas gauge again, then click **Compact**.
   - Expected: panel hides, session compaction proceeds (ObsidiBot notice: "compacting session…" then "session compacted.").
6. Verify the panel does not appear when there is no active session (e.g., after clearing the session): clicking the gauge should show a Notice instead.

## Regression Risk

- Session persistence: not affected — `compactSession()` itself is unchanged.
- Vault file operations: not affected.
- Claude Code subprocess lifecycle: not affected — spawn path is identical.
- Token gauge display/update logic: not affected — only the click handler changed.

## Notes

The panel is rendered as an absolutely-positioned child of `.obsidibot-view` and uses a CSS `transform: translateX` transition (220 ms ease). No JavaScript animation timers.