### PR TITLE
feat(session): fix session replay fidelity + compaction filtering (#99)

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -763,7 +763,21 @@ export class ClaudeView extends ItemView {
     this.inputDraft = '';
     this.inputEl.value = '';
     this.setSendState(true);
-    this.appendMessage('user', prompt);
+    // Capture manually-added contexts now (before pendingContexts is cleared after send)
+    // and convert to InjectedContext for badge display in the message bubble.
+    const liveContextBadges: InjectedContext[] = this.pendingContexts
+      .filter(c => c.type === 'url' || c.type === 'image' || c.type === 'pdf' || !c.type || c.type === 'text')
+      .map(c => {
+        if (c.type === 'url')   return { type: 'url' as const,        url: c.text };
+        if (c.type === 'image') return { type: 'image' as const,      source: c.source, path: c.text };
+        if (c.type === 'pdf')   return { type: 'pdf' as const,        source: c.source, path: c.text };
+        return                         { type: 'attachment' as const,  source: c.source };
+      });
+    if (liveContextBadges.length > 0) {
+      this.appendUserMessageWithContexts(prompt, liveContextBadges);
+    } else {
+      this.appendMessage('user', prompt);
+    }
 
     // Response group: tool events (above) + assistant bubble + token stats (below)
     const responseGroupEl = this.messagesEl.createDiv({ cls: 'obsidibot-response-group' });
@@ -805,8 +819,8 @@ export class ClaudeView extends ItemView {
       const contextBlock = this.pendingContexts
         .map(c => {
           if (c.type === 'url') return `<obsidibot-context type="url" url="${c.text}"></obsidibot-context>`;
-          if (c.type === 'image') return `<obsidibot-context type="image" source="${c.source}" path="${c.text}"></obsidibot-context>\nRead this file to view the image: ${c.text}`;
-          if (c.type === 'pdf') return `<obsidibot-context type="pdf" source="${c.source}" path="${c.text}"></obsidibot-context>\nRead this file to view the document: ${c.text}`;
+          if (c.type === 'image') return `<obsidibot-context type="image" source="${c.source}" path="${c.text}">Read this file to view the image: ${c.text}</obsidibot-context>`;
+          if (c.type === 'pdf') return `<obsidibot-context type="pdf" source="${c.source}" path="${c.text}">Read this file to view the document: ${c.text}</obsidibot-context>`;
           return `<obsidibot-context type="attachment" source="${c.source}">${c.text}</obsidibot-context>`;
         })
         .join('\n\n');

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1754,13 +1754,19 @@ export class ClaudeView extends ItemView {
     return el;
   }
 
-  /** Render a replayed user message with context badges above the text. */
+  /** Render a replayed user message with context badges above the text.
+   *  Only manually-added context types are shown — auto-injected ones
+   *  (active-note, split-view, stacked-tabs, system-message) are silent
+   *  in the live UI and should stay silent on replay. */
   private appendUserMessageWithContexts(text: string, contexts: InjectedContext[]): HTMLElement {
     const el = this.messagesEl.createDiv({ cls: 'obsidibot-message obsidibot-user' });
 
-    if (contexts.length > 0) {
+    const manualContexts = contexts.filter(ctx =>
+      (ctx.type === 'attachment' || ctx.type === 'url' || ctx.type === 'image' || ctx.type === 'pdf')
+    );
+    if (manualContexts.length > 0) {
       const badgeStrip = el.createDiv({ cls: 'obsidibot-replay-context-strip' });
-      for (const ctx of contexts) {
+      for (const ctx of manualContexts) {
         const badge = badgeStrip.createSpan({ cls: 'obsidibot-replay-context-badge' });
         const iconEl = badge.createSpan({ cls: 'obsidibot-replay-context-icon' });
         setIcon(iconEl, this.iconForContextType(ctx.type));

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1758,12 +1758,14 @@ export class ClaudeView extends ItemView {
   private appendUserMessageWithContexts(text: string, contexts: InjectedContext[]): HTMLElement {
     const el = this.messagesEl.createDiv({ cls: 'obsidibot-message obsidibot-user' });
 
-    const badgeStrip = el.createDiv({ cls: 'obsidibot-replay-context-strip' });
-    for (const ctx of contexts) {
-      const badge = badgeStrip.createSpan({ cls: 'obsidibot-replay-context-badge' });
-      const iconEl = badge.createSpan({ cls: 'obsidibot-pending-context-icon' });
-      setIcon(iconEl, this.iconForContextType(ctx.type));
-      badge.createSpan({ cls: 'obsidibot-replay-context-label', text: this.labelForContext(ctx) });
+    if (contexts.length > 0) {
+      const badgeStrip = el.createDiv({ cls: 'obsidibot-replay-context-strip' });
+      for (const ctx of contexts) {
+        const badge = badgeStrip.createSpan({ cls: 'obsidibot-replay-context-badge' });
+        const iconEl = badge.createSpan({ cls: 'obsidibot-replay-context-icon' });
+        setIcon(iconEl, this.iconForContextType(ctx.type));
+        badge.createSpan({ cls: 'obsidibot-replay-context-label', text: this.labelForContext(ctx) });
+      }
     }
 
     el.createSpan({ text });

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -12,6 +12,8 @@ import { log, estimateTokens } from './utils/logger';
 import { extractToolDetail } from './utils/toolFormatting';
 import {
   StoredSession,
+  InjectedContext,
+  InjectedContextType,
   saveSession,
   saveSessionAtTop,
   loadAllSessions,
@@ -691,8 +693,15 @@ export class ClaudeView extends ItemView {
       const messages = loadSessionMessages(session.claudeSessionId);
       if (messages.length > 0) {
         for (const msg of messages) {
-          if (msg.role === 'user') {
-            this.appendMessage('user', msg.content);
+          if (msg.role === 'separator') {
+            const divider = this.messagesEl.createDiv({ cls: 'obsidibot-compaction-divider' });
+            divider.setText(msg.content);
+          } else if (msg.role === 'user') {
+            if (msg.contexts && msg.contexts.length > 0) {
+              this.appendUserMessageWithContexts(msg.content, msg.contexts);
+            } else {
+              this.appendMessage('user', msg.content);
+            }
           } else {
             const el = this.appendMessage('assistant', '');
             const { clean } = extractActions(msg.content);
@@ -780,14 +789,14 @@ export class ClaudeView extends ItemView {
       if (isSplit && this.plugin.settings.injectSplitPaneFiles) {
         const paths = leaves.map(l => (l.view as any).file?.path).filter(Boolean) as string[];
         const unique = [...new Set(paths)];
-        activeFileNote = `[Open in split view: ${unique.join(' | ')}]\n\n`;
+        activeFileNote = `<obsidibot-context type="split-view" paths="${unique.join('|')}"></obsidibot-context>\n\n`;
       } else if (isStacked && this.plugin.settings.injectStackedTabFiles) {
         const paths = leaves.map(l => (l.view as any).file?.path).filter(Boolean) as string[];
         const unique = [...new Set(paths)];
-        activeFileNote = `[Open in stacked tabs: ${unique.join(' | ')}]\n\n`;
+        activeFileNote = `<obsidibot-context type="stacked-tabs" paths="${unique.join('|')}"></obsidibot-context>\n\n`;
       } else {
         const activeFile = this.app.workspace.getActiveFile();
-        activeFileNote = activeFile ? `[Active note: ${activeFile.path}]\n\n` : '';
+        activeFileNote = activeFile ? `<obsidibot-context type="active-note" path="${activeFile.path}"></obsidibot-context>\n\n` : '';
       }
     }
 
@@ -795,10 +804,10 @@ export class ClaudeView extends ItemView {
     if (this.pendingContexts.length > 0) {
       const contextBlock = this.pendingContexts
         .map(c => {
-          if (c.type === 'url') return `**[URL: ${c.text}]**`;
-          if (c.type === 'image') return `**[Attached image: ${c.source}]**\nRead this file to view the image: ${c.text}`;
-          if (c.type === 'pdf') return `**[Attached PDF: ${c.source}]**\nRead this file to view the document: ${c.text}`;
-          return `**[Context from ${c.source}]**\n${c.text}`;
+          if (c.type === 'url') return `<obsidibot-context type="url" url="${c.text}"></obsidibot-context>`;
+          if (c.type === 'image') return `<obsidibot-context type="image" source="${c.source}" path="${c.text}"></obsidibot-context>\nRead this file to view the image: ${c.text}`;
+          if (c.type === 'pdf') return `<obsidibot-context type="pdf" source="${c.source}" path="${c.text}"></obsidibot-context>\nRead this file to view the document: ${c.text}`;
+          return `<obsidibot-context type="attachment" source="${c.source}">${c.text}</obsidibot-context>`;
         })
         .join('\n\n');
       finalPrompt = `${contextBlock}\n\n${prompt}`;
@@ -826,7 +835,7 @@ export class ClaudeView extends ItemView {
       }
     } else {
       if (this.pendingSystemMessage) {
-        finalPrompt = `${this.pendingSystemMessage}\n\n${finalPrompt}`;
+        finalPrompt = `<obsidibot-context type="system-message">${this.pendingSystemMessage}</obsidibot-context>\n\n${finalPrompt}`;
         this.pendingSystemMessage = null;
       }
       log(`[CONTINUE SESSION ${this.currentSessionId?.substring(0, 8)}] Prompt: ~${estimateTokens(finalPrompt)} tokens`);
@@ -1743,6 +1752,50 @@ export class ClaudeView extends ItemView {
     this.scrollToBottom();
     this.updateExportBtn();
     return el;
+  }
+
+  /** Render a replayed user message with context badges above the text. */
+  private appendUserMessageWithContexts(text: string, contexts: InjectedContext[]): HTMLElement {
+    const el = this.messagesEl.createDiv({ cls: 'obsidibot-message obsidibot-user' });
+
+    const badgeStrip = el.createDiv({ cls: 'obsidibot-replay-context-strip' });
+    for (const ctx of contexts) {
+      const badge = badgeStrip.createSpan({ cls: 'obsidibot-replay-context-badge' });
+      const iconEl = badge.createSpan({ cls: 'obsidibot-pending-context-icon' });
+      setIcon(iconEl, this.iconForContextType(ctx.type));
+      badge.createSpan({ cls: 'obsidibot-replay-context-label', text: this.labelForContext(ctx) });
+    }
+
+    el.createSpan({ text });
+    this.scrollToBottom();
+    this.updateExportBtn();
+    return el;
+  }
+
+  private iconForContextType(type: InjectedContextType): string {
+    switch (type) {
+      case 'image':        return 'image';
+      case 'pdf':          return 'file-text';
+      case 'url':          return 'link';
+      case 'system-message': return 'refresh-cw';
+      case 'split-view':
+      case 'stacked-tabs': return 'layout';
+      default:             return 'paperclip';
+    }
+  }
+
+  private labelForContext(ctx: InjectedContext): string {
+    switch (ctx.type) {
+      case 'active-note':   return ctx.path ?? 'active note';
+      case 'split-view':    return `Split: ${ctx.paths?.replace(/\|/g, ', ') ?? ''}`;
+      case 'stacked-tabs':  return `Stacked: ${ctx.paths?.replace(/\|/g, ', ') ?? ''}`;
+      case 'attachment':    return ctx.source ?? 'attachment';
+      case 'url':           return ctx.url ?? 'url';
+      case 'image':         return ctx.source ?? 'image';
+      case 'pdf':           return ctx.source ?? 'pdf';
+      case 'system-message': return 'context refresh';
+      default:              return ctx.type;
+    }
   }
 
   /** Enable or disable the export button based on whether the session has any messages. */

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -153,7 +153,8 @@ function extractObsidiBotContexts(content: string): { clean: string; contexts: I
 }
 
 const COMPACTION_SUMMARY_PREFIX = 'This session is being continued from a previous conversation';
-const INTERNAL_USER_PREFIXES = ['<local-command-caveat>', '<command-name>'];
+// All <local-command-*> variants (caveat, stdout, stderr, etc.) are internal noise
+const INTERNAL_USER_PREFIXES = ['<local-command-', '<command-name>'];
 
 function findJsonlPath(claudeSessionId: string): string | undefined {
   const projectsDir = join(homedir(), '.claude', 'projects');

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -101,11 +101,59 @@ export function titleFromPrompt(prompt: string): string {
   return first.length > 60 ? first.substring(0, 60) + '…' : first;
 }
 
+export type InjectedContextType =
+  | 'active-note'
+  | 'split-view'
+  | 'stacked-tabs'
+  | 'attachment'
+  | 'url'
+  | 'image'
+  | 'pdf'
+  | 'system-message';
+
+export interface InjectedContext {
+  type: InjectedContextType;
+  path?: string;     // active-note
+  paths?: string;    // split-view, stacked-tabs (pipe-separated)
+  source?: string;   // attachment, image, pdf
+  url?: string;      // url
+  content?: string;  // attachment body text
+}
+
 export interface ChatMessage {
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'separator';
   content: string;
   timestamp: string;
+  contexts?: InjectedContext[];
 }
+
+/**
+ * Strip all <obsidibot-context> tags from content and return the clean text
+ * plus a structured list of the injected contexts for badge rendering on replay.
+ */
+function extractObsidiBotContexts(content: string): { clean: string; contexts: InjectedContext[] } {
+  const contexts: InjectedContext[] = [];
+  // Matches both self-closing-style and body-carrying tags
+  const TAG_RE = /<obsidibot-context\s([^>]*)>([\s\S]*?)<\/obsidibot-context>/g;
+  const ATTR_RE = /(\w[\w-]*)="([^"]*)"/g;
+
+  const clean = content.replace(TAG_RE, (_match, attrStr: string, body: string) => {
+    const ctx: Record<string, string> = {};
+    let m: RegExpExecArray | null;
+    ATTR_RE.lastIndex = 0;
+    while ((m = ATTR_RE.exec(attrStr)) !== null) {
+      ctx[m[1]] = m[2];
+    }
+    if (body.trim()) ctx['content'] = body.trim();
+    if (ctx['type']) contexts.push(ctx as unknown as InjectedContext);
+    return '';
+  });
+
+  return { clean: clean.trim(), contexts };
+}
+
+const COMPACTION_SUMMARY_PREFIX = 'This session is being continued from a previous conversation';
+const INTERNAL_USER_PREFIXES = ['<local-command-caveat>', '<command-name>'];
 
 function findJsonlPath(claudeSessionId: string): string | undefined {
   const projectsDir = join(homedir(), '.claude', 'projects');
@@ -139,18 +187,31 @@ export function loadSessionMessages(claudeSessionId: string): ChatMessage[] {
     const lines = readFileSync(jsonlPath, 'utf8').split('\n').filter(l => l.trim());
     const messages: ChatMessage[] = [];
     let isFirstUser = true;
+    let skipNextUser = false;
 
     for (const line of lines) {
       try {
         const entry = JSON.parse(line) as Record<string, unknown>;
 
+        // Compaction boundary — insert a divider and skip the summary that follows
+        if (entry.type === 'system' && (entry as Record<string, unknown>).subtype === 'compact_boundary') {
+          skipNextUser = true;
+          messages.push({ role: 'separator', content: '─── conversation compacted ───', timestamp: entry.timestamp as string });
+          continue;
+        }
+
         if (entry.type === 'user') {
+          // Drop the compaction summary that immediately follows a compact_boundary
+          if (skipNextUser) {
+            skipNextUser = false;
+            continue;
+          }
+
           const msg = entry.message as Record<string, unknown> | undefined;
           let content: string;
           if (typeof msg?.content === 'string') {
             content = msg.content;
           } else if (Array.isArray(msg?.content)) {
-            // Claude stores user messages as content block arrays in some formats
             content = (msg.content as Array<Record<string, unknown>>)
               .filter(b => b.type === 'text')
               .map(b => b.text as string)
@@ -158,12 +219,28 @@ export function loadSessionMessages(claudeSessionId: string): ChatMessage[] {
           } else {
             content = '';
           }
+
+          // Filter internal command noise
+          if (INTERNAL_USER_PREFIXES.some(p => content.startsWith(p))) continue;
+          // Belt-and-suspenders: catch any compaction summary not preceded by compact_boundary
+          if (content.startsWith(COMPACTION_SUMMARY_PREFIX)) continue;
+
           if (isFirstUser) {
             // Strip injected vault context from display
             content = content.replace(/<vault_context>[\s\S]*?<\/vault_context>\s*/g, '').trim();
             isFirstUser = false;
           }
-          if (content) messages.push({ role: 'user', content, timestamp: entry.timestamp as string });
+
+          // Strip <obsidibot-context> tags and collect metadata for badge rendering
+          const { clean, contexts } = extractObsidiBotContexts(content);
+          if (clean || contexts.length > 0) {
+            messages.push({
+              role: 'user',
+              content: clean,
+              timestamp: entry.timestamp as string,
+              contexts: contexts.length > 0 ? contexts : undefined,
+            });
+          }
 
         } else if (entry.type === 'assistant') {
           const msg = entry.message as Record<string, unknown> | undefined;

--- a/styles.css
+++ b/styles.css
@@ -477,7 +477,7 @@
 .obsidibot-replay-context-strip {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 6px;
   margin-bottom: 5px;
 }
 
@@ -485,14 +485,25 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  background: var(--background-modifier-border);
-  border-radius: 4px;
-  padding: 2px 6px;
   font-size: 0.78em;
+  opacity: 0.8;
+}
+
+.obsidibot-replay-context-icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--interactive-accent);
+}
+
+.obsidibot-replay-context-icon svg {
+  width: 11px;
+  height: 11px;
 }
 
 .obsidibot-replay-context-label {
-  color: var(--text-muted);
+  color: var(--interactive-accent);
+  font-weight: 500;
 }
 
 /* Markdown content inside assistant messages */

--- a/styles.css
+++ b/styles.css
@@ -462,6 +462,39 @@
   letter-spacing: 0.05em;
 }
 
+/* ── Compaction divider (shown when a session was compacted) ── */
+.obsidibot-compaction-divider {
+  align-self: center;
+  text-align: center;
+  font-size: 0.75em;
+  color: var(--text-faint);
+  font-style: italic;
+  padding: 4px 0;
+  letter-spacing: 0.05em;
+}
+
+/* ── Replay context badge strip (inside replayed user message bubbles) ── */
+.obsidibot-replay-context-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 5px;
+}
+
+.obsidibot-replay-context-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--background-modifier-border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.78em;
+}
+
+.obsidibot-replay-context-label {
+  color: var(--text-muted);
+}
+
 /* Markdown content inside assistant messages */
 .obsidibot-assistant p:last-child {
   margin-bottom: 0;


### PR DESCRIPTION
## Summary

- Replaces all plain-text context prefixes (`[Active note: ...]`, `[Open in split view: ...]`, etc.) with structured `<obsidibot-context type="...">` XML tags at injection time, so a single regex strips them on replay — no more per-pattern whack-a-mole
- On replay, context metadata is parsed back and rendered as small badge indicators inside the user message bubble, matching what the live session showed
- Compaction summaries (`type: system, subtype: compact_boundary` + following user turn) are suppressed and replaced with a `─── conversation compacted ───` divider
- Internal command noise (`<local-command-caveat>`, `<command-name>`) is filtered from replayed history

## Files changed

- `src/utils/sessionStorage.ts` — new `InjectedContext`/`InjectedContextType` types, `extractObsidiBotContexts()` helper, rewritten `loadSessionMessages` parser loop
- `src/ClaudeView.ts` — XML tags at all five injection sites, updated replay loop, new `appendUserMessageWithContexts()` badge renderer
- `styles.css` — `.obsidibot-compaction-divider`, `.obsidibot-replay-context-strip/badge/label`

## Test plan

- [ ] Start a new session with an active note open — confirm `[Active note: ...]` no longer appears raw in the user bubble
- [ ] Resume that session — confirm the active note shows as a badge above the message text instead of raw text
- [ ] Attach a file/URL/image in a message, then resume — confirm badges render correctly
- [ ] Trigger `/compact` in a long session, then resume — confirm compaction summary is gone and divider appears instead
- [ ] Verify old sessions (pre-fix) still load without crashing (badges will be absent, old prefix text will still show — acceptable regression boundary)

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)