### PR TITLE
feat: recent sessions list on welcome screen

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1222,6 +1222,25 @@ export class ClaudeView extends ItemView {
     sprite.addEventListener('click', () => new AboutModal(this.app, this.plugin).open());
     body.createEl('p', { cls: 'obsidibot-welcome-greeting', text: greetingText });
     body.createEl('p', { cls: 'obsidibot-welcome-tip', text: tip });
+
+    // Recent sessions footer
+    const sessions = loadAllSessions(this.getVaultRoot(), this.getSessionsDir(), this.app.vault.configDir)
+      .filter(s => s.id !== this.currentSessionFileId);
+    if (sessions.length > 0) {
+      const recent = welcome.createDiv({ cls: 'obsidibot-welcome-recent' });
+      recent.createEl('p', { cls: 'obsidibot-welcome-recent-label', text: 'Recent sessions' });
+      const list = recent.createDiv({ cls: 'obsidibot-welcome-recent-list' });
+      sessions.slice(0, 3).forEach(session => {
+        const item = list.createDiv({ cls: 'obsidibot-welcome-recent-item' });
+        item.createSpan({ cls: 'obsidibot-welcome-recent-title', text: session.userLabel || session.title });
+        item.createSpan({ cls: 'obsidibot-welcome-recent-date', text: relativeDate(session.updatedAt) });
+        item.addEventListener('click', () => void this.loadSession(session));
+      });
+      if (sessions.length > 3) {
+        const more = recent.createEl('span', { cls: 'obsidibot-welcome-recent-more', text: 'more…' });
+        more.addEventListener('click', () => this.showSessionHistory());
+      }
+    }
   }
 
   private renderSetupPanel() {
@@ -2425,4 +2444,17 @@ class AttachUrlModal extends Modal {
     setTimeout(() => input.focus(), 50);
   }
   onClose() { this.contentEl.empty(); }
+}
+
+function relativeDate(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }

--- a/styles.css
+++ b/styles.css
@@ -529,7 +529,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 16px 20px 40px;
+  padding: 16px 20px 8px;
   user-select: none;
 }
 
@@ -589,6 +589,75 @@
   text-align: center;
   max-width: 280px;
   line-height: 1.5;
+}
+
+.obsidibot-welcome-recent {
+  width: 100%;
+  padding-top: 8px;
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.obsidibot-welcome-recent-label {
+  margin: 0 0 2px;
+  font-size: 0.75em;
+  font-weight: 600;
+  color: var(--text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.obsidibot-welcome-recent-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.obsidibot-welcome-recent-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  padding: 3px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.obsidibot-welcome-recent-item:hover {
+  background: var(--background-modifier-hover);
+}
+
+.obsidibot-welcome-recent-title {
+  font-size: 0.88em;
+  color: var(--text-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.obsidibot-welcome-recent-date {
+  font-size: 0.75em;
+  color: var(--text-faint);
+  flex-shrink: 0;
+}
+
+.obsidibot-welcome-recent-more {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  box-shadow: none;
+  padding: 2px 6px 0;
+  font-size: 0.78em;
+  color: var(--text-faint);
+  cursor: pointer;
+}
+
+.obsidibot-welcome-recent-more:hover {
+  color: var(--text-accent);
+  text-decoration: underline;
 }
 
 .obsidibot-setup-card {


### PR DESCRIPTION
## Summary

- Recent sessions list (up to 3) pinned to the bottom of the welcome screen
- Filters out the current session so only prior sessions appear
- Clicking a session item resumes it
- "more…" plain-text link opens the session manager
- Reduced bottom padding and `margin-top: auto` to keep the list close to the input box

## Test plan

- [ ] Open a fresh session — welcome screen shows with no recent sessions (or up to 3 if prior sessions exist)
- [ ] Verify the current session does not appear in the list
- [ ] Click a recent session item — session resumes correctly
- [ ] Click "more…" — session manager opens
- [ ] Send a message — welcome screen is dismissed
- [ ] Relative timestamps render correctly (e.g. "2 hours ago", "yesterday")