### PR TITLE
feat: redesign About modal

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -8,3 +8,4 @@ declare module '*.png' {
   const dataUrl: string;
   export default dataUrl;
 }
+

--- a/src/modals/AboutModal.ts
+++ b/src/modals/AboutModal.ts
@@ -1,5 +1,52 @@
-import { App, Modal, Plugin } from 'obsidian';
+import { App, Modal, Plugin, setIcon } from 'obsidian';
 import logoDataUrl from '../../assets/media/logo.png';
+
+// Inline SVG — no file import, no runtime string replacement, attributes set directly.
+// stroke-width="4" matches Lucide's visual weight at this viewBox size (48×48 vs Lucide's 24×24).
+const DISCORD_SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"
+  fill="none" stroke="currentColor" stroke-width="3"
+  stroke-linecap="round" stroke-linejoin="round"
+  width="100%" height="100%">
+  <path d="M17.59,34.1733c-.89,1.3069-1.8944,2.6152-2.91,3.8267C7.3,37.79,4.5,33,4.5,33A44.83,44.83,0,0,1,9.31,13.48,16.47,16.47,0,0,1,18.69,10l1,2.31A32.6875,32.6875,0,0,1,24,12a32.9643,32.9643,0,0,1,4.33.3l1-2.31a16.47,16.47,0,0,1,9.38,3.51A44.8292,44.8292,0,0,1,43.5,33s-2.8,4.79-10.18,5a47.4193,47.4193,0,0,1-2.86-3.81m6.46-2.9c-3.84,1.9454-7.5555,3.89-12.92,3.89s-9.08-1.9446-12.92-3.89"/>
+  <circle cx="17.847" cy="26.23" r="3.35"/>
+  <circle cx="30.153" cy="26.23" r="3.35"/>
+</svg>`;
+
+interface LinkItem {
+  icon: string;
+  title: string;
+  desc: string;
+  label: string;
+  href: string;
+  accent?: boolean;
+  svgInline?: string;
+}
+
+const LINK_ITEMS: LinkItem[] = [
+  {
+    icon: 'book-open',
+    title: 'Documentation',
+    desc: 'Official guide, skill reference, and setup instructions.',
+    label: 'Visit',
+    href: 'https://www.scottkirvan.com/ObsidiBot/',
+    accent: true,
+  },
+  {
+    icon: '',
+    svgInline: DISCORD_SVG,
+    title: 'Discord',
+    desc: 'Chat with other ObsidiBot users and get support.',
+    label: 'Join',
+    href: 'https://discord.gg/TN6XJSNK5Y',
+  },
+  {
+    icon: 'github',
+    title: 'GitHub',
+    desc: 'Source code, issues, and release notes.',
+    label: 'View',
+    href: 'https://github.com/ScottKirvan/ObsidiBot',
+  },
+];
 
 export class AboutModal extends Modal {
   private plugin: Plugin;
@@ -13,39 +60,39 @@ export class AboutModal extends Modal {
     const { contentEl } = this;
     contentEl.addClass('obsidibot-about-modal');
 
-    // Logo — embedded as base64 data URL at build time (portable across all install methods)
-    const logoWrap = contentEl.createDiv({ cls: 'obsidibot-about-logo' });
-    const logo = logoWrap.createEl('img');
-    logo.src = logoDataUrl;
-    logo.alt = 'ObsidiBot logo';
-
-    // Name + version
-    contentEl.createEl('h2', { text: 'ObsidiBot', cls: 'obsidibot-about-title' });
-    contentEl.createEl('p', { text: `Version ${this.plugin.manifest.version}`, cls: 'obsidibot-about-version' });
-
-    contentEl.createEl('p', {
-      text: 'Claude Code agentic file management for Obsidian vaults.',
-      cls: 'obsidibot-about-desc',
+    const header = contentEl.createDiv({ cls: 'obsidibot-about-header' });
+    const logoImg = header.createEl('img', { cls: 'obsidibot-about-logo' });
+    logoImg.src = logoDataUrl;
+    logoImg.alt = 'ObsidiBot';
+    header.createEl('div', { text: 'ObsidiBot', cls: 'obsidibot-about-name' });
+    header.createEl('div', {
+      text: `Version ${this.plugin.manifest.version}`,
+      cls: 'obsidibot-about-version',
     });
 
-    // Links
-    const btnRow = contentEl.createDiv({ cls: 'obsidibot-about-buttons' });
+    const list = contentEl.createDiv({ cls: 'obsidibot-about-list' });
+    for (const item of LINK_ITEMS) {
+      const row = list.createDiv({ cls: 'obsidibot-about-item' });
 
-    const helpBtn = btnRow.createEl('a', {
-      text: 'Documentation',
-      href: 'https://www.scottkirvan.com/ObsidiBot/',
-      cls: 'mod-cta obsidibot-about-link-btn',
-    });
-    helpBtn.setAttr('target', '_blank');
-    helpBtn.setAttr('rel', 'noopener');
+      const iconEl = row.createDiv({ cls: 'obsidibot-about-item-icon' });
+      if (item.svgInline) {
+        iconEl.innerHTML = item.svgInline;
+      } else {
+        setIcon(iconEl, item.icon);
+      }
 
-    const discordBtn = btnRow.createEl('a', {
-      text: 'Discord',
-      href: 'https://discord.gg/TN6XJSNK5Y',
-      cls: 'obsidibot-about-link-btn',
-    });
-    discordBtn.setAttr('target', '_blank');
-    discordBtn.setAttr('rel', 'noopener');
+      const text = row.createDiv({ cls: 'obsidibot-about-item-text' });
+      text.createEl('div', { text: item.title, cls: 'obsidibot-about-item-title' });
+      text.createEl('div', { text: item.desc, cls: 'obsidibot-about-item-desc' });
+
+      const btn = row.createEl('a', {
+        text: item.label,
+        cls: 'obsidibot-about-item-btn' + (item.accent ? ' mod-cta' : ''),
+        href: item.href,
+      });
+      btn.setAttr('target', '_blank');
+      btn.setAttr('rel', 'noopener');
+    }
   }
 
   onClose() {

--- a/styles.css
+++ b/styles.css
@@ -205,56 +205,103 @@
 
 /* ── About modal ── */
 .obsidibot-about-modal {
-  text-align: center;
-  padding: 16px 8px 8px;
+  padding: 8px 4px 4px;
 }
 
-.obsidibot-about-logo img {
-  width: 80px;
-  height: 80px;
-  border-radius: 16px;
+.obsidibot-about-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px 0 20px;
+}
+
+.obsidibot-about-logo {
+  width: 144px;
+  height: 144px;
+  border-radius: 28px;
   object-fit: cover;
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
-.obsidibot-about-title {
-  margin: 0 0 4px;
+.obsidibot-about-name {
+  font-size: 1.5em;
+  font-weight: 700;
+  color: var(--text-normal);
+  margin-bottom: 4px;
 }
 
 .obsidibot-about-version {
   color: var(--text-muted);
-  font-size: 0.85em;
-  margin: 0 0 12px;
+  font-size: 0.82em;
 }
 
-.obsidibot-about-desc {
-  color: var(--text-muted);
-  font-size: 0.9em;
-  margin: 0 0 20px;
+.obsidibot-about-list {
+  margin-top: 16px;
+  background: var(--background-secondary);
+  border-radius: var(--radius-m, 8px);
+  overflow: hidden;
 }
 
-.obsidibot-about-buttons {
+.obsidibot-about-item {
   display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+}
+
+.obsidibot-about-item-icon {
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
   justify-content: center;
-  gap: 10px;
+  color: var(--text-muted);
 }
 
-.obsidibot-about-link-btn {
-  padding: 6px 16px;
-  border-radius: 4px;
-  border: 1px solid var(--background-modifier-border);
-  text-decoration: none;
-  font-size: 0.9em;
+.obsidibot-about-item-icon svg {
+  width: 44px;
+  height: 44px;
+}
+
+.obsidibot-about-item-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.obsidibot-about-item-title {
+  font-size: 0.95em;
+  font-weight: 500;
   color: var(--text-normal);
+  margin-bottom: 2px;
 }
 
-.obsidibot-about-link-btn.mod-cta {
+.obsidibot-about-item-desc {
+  font-size: 0.8em;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.obsidibot-about-item-btn {
+  flex-shrink: 0;
+  padding: 5px 14px;
+  border-radius: var(--radius-s, 4px);
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  text-decoration: none;
+  font-size: 0.85em;
+  color: var(--text-normal);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.obsidibot-about-item-btn.mod-cta {
   background: var(--interactive-accent);
   color: var(--text-on-accent);
   border-color: transparent;
 }
 
-.obsidibot-about-link-btn:hover {
+.obsidibot-about-item-btn:hover {
   opacity: 0.85;
 }
 


### PR DESCRIPTION
## Summary

- Replaces simple button row with an Obsidian-style card list (icon + title + description + action button per row)
- Documentation (accent/violet), Discord, and GitHub rows
- Discord icon inlined as SVG with `currentColor` stroke — theme-aware, no file import needed
- Robot logo scaled to 144px
- All styles scoped under new CSS classes; old classes removed

## Test plan

- [ ] Open About modal — header logo, name, and version display correctly
- [ ] All three rows render with icon, title, description, and button
- [ ] Discord icon matches visual weight of Lucide icons in both light and dark themes
- [ ] Documentation button uses accent color; Discord and GitHub use outlined style
- [ ] All three links open in a new tab