### PR TITLE
fix: disable debug logging by default

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -75,7 +75,7 @@ export const DEFAULT_SETTINGS: ObsidiBotSettings = {
   confirmUnlistedCommands: true,
   commandDenylist: [],
   permissionMode: 'standard',
-  logEnabled: true,
+  logEnabled: false,
   logFilePath: '',
   logVerbosity: 'normal',
   atMentionExtensions: 'md, canvas, pdf, fountain, txt',


### PR DESCRIPTION
## What

Debug logging was enabled by default, creating a persistent plaintext record of full session content — prompts, tool inputs and outputs, streamed responses — at `.obsidian/plugins/obsidibot/obsidibot-debug.log`. Any process with vault read access could read it without the user ever opting in.

This is security finding **S4** from the v2.10.0 code review.

## Change

`logEnabled` default: `true` → `false`

Existing users who already have `logEnabled: true` saved in `data.json` are unaffected — Obsidian merges saved settings over defaults, so their logging stays on until they actively turn it off.

## How to test

1. Fresh install (or delete `data.json` to simulate one). Confirm no `obsidibot-debug.log` is created after starting a session.
2. Enable logging in Settings → ObsidiBot. Confirm the log file is created and captures session content as expected.
3. Existing user with `logEnabled: true` in `data.json`: confirm logging continues to work unchanged.