### PR TITLE
fix: remove daily-notes from default command allowlist

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -71,7 +71,7 @@ export const DEFAULT_SETTINGS: ObsidiBotSettings = {
   vaultTreeDepth: 3,
   skipContextFilePrompt: false,
   uiBridgeEnabled: true,
-  commandAllowlist: ['switcher:open', 'daily-notes', 'editor:open-search'],
+  commandAllowlist: ['switcher:open', 'editor:open-search'],
   confirmUnlistedCommands: true,
   commandDenylist: [],
   permissionMode: 'standard',


### PR DESCRIPTION
## What

`daily-notes` was included in the default command allowlist, meaning it could be executed silently (no confirmation prompt) by any allowlisted `run-command` UI bridge action. The `daily-notes` command creates a new daily note if one does not exist for today — it is not a read-only operation.

This is security finding **S5** from the v2.10.0 code review.

Closes #168

## Change

`commandAllowlist` default: `['switcher:open', 'daily-notes', 'editor:open-search']` → `['switcher:open', 'editor:open-search']`

The two remaining defaults are genuinely read-only UI actions. Users who want `daily-notes` on their allowlist can add it manually in Settings → ObsidiBot.

## How to test

1. Fresh install (or clear `data.json`). Confirm `daily-notes` is not in the default allowlist.
2. Ask Claude to open today's daily note. With `confirmUnlistedCommands: true` (default), a confirmation prompt should appear before `daily-notes` executes.
3. Confirm `switcher:open` and `editor:open-search` still fire without a prompt.