### PR TITLE
feat: always-visible permission mode icon in input toolbar

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -31,6 +31,11 @@ export default class ObsidiBotPlugin extends Plugin {
   async onload() {
     await this.loadSettings();
 
+    if (this.settings.permissionMode === 'full' && !this.settings.persistFullAccess) {
+      this.settings.permissionMode = 'standard';
+      await this.saveSettings();
+    }
+
     const vaultRoot = this.getVaultRoot();
     initLogger(vaultRoot, {
       enabled: this.settings.logEnabled,
@@ -366,6 +371,11 @@ export default class ObsidiBotPlugin extends Plugin {
 
   async saveSettings() {
     await this.saveData(this.settings);
+  }
+
+  notifyPermissionChanged(): void {
+    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDE);
+    if (leaves.length) (leaves[0].view as ClaudeView).onSettingsChanged();
   }
 
   private resolveCommandsFolder(): string {

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -408,17 +408,17 @@ export class ClaudeView extends ItemView {
     switch (mode) {
       case 'readonly':
         setIcon(this.permissionIconEl, 'eye');
-        this.permissionIconEl.title = 'Read-only — no writes or shell commands. Click to change.';
+        this.permissionIconEl.title = 'Permissions: Read-only — no writes or shell commands. Click to change.';
         this.permissionIconEl.addClass('obsidibot-perm-readonly');
         break;
       case 'full':
         setIcon(this.permissionIconEl, 'triangle-alert');
-        this.permissionIconEl.title = 'Full access — all tools including bash. Click to change.';
+        this.permissionIconEl.title = 'Permissions: Full access — all tools including bash. Click to change.';
         this.permissionIconEl.addClass('obsidibot-perm-full');
         break;
       default:
         setIcon(this.permissionIconEl, 'shield');
-        this.permissionIconEl.title = 'Standard — files + web, no bash. Click to change.';
+        this.permissionIconEl.title = 'Permissions: Standard — files + web, no bash. Click to change.';
         this.permissionIconEl.addClass('obsidibot-perm-standard');
     }
   }

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -106,6 +106,7 @@ export class ClaudeView extends ItemView {
   private tokenGaugeEl: SVGElement;
   private attachPopoverEl: HTMLElement;
   private compactConfirmEl: HTMLElement;
+  private permissionIconEl!: HTMLButtonElement;
   private sessionContextTokens = 0;
   static readonly CONTEXT_WINDOW = 200_000;
   private atDropdownIndex = -1;
@@ -201,6 +202,13 @@ export class ClaudeView extends ItemView {
     });
 
     const inputToolbar = inputArea.createDiv({ cls: 'obsidibot-input-toolbar' });
+
+    this.permissionIconEl = inputToolbar.createEl('button', { cls: 'obsidibot-icon-btn obsidibot-input-toolbar-btn obsidibot-permission-icon' });
+    this.permissionIconEl.addEventListener('click', () => {
+      this.appInternal.setting.open();
+      this.appInternal.setting.openTabById('obsidibot');
+    });
+    this.updatePermissionIcon();
 
     this.attachBtn = inputToolbar.createEl('button', { cls: 'obsidibot-icon-btn obsidibot-input-toolbar-btn' });
     setIcon(this.attachBtn, 'paperclip');
@@ -389,8 +397,35 @@ export class ClaudeView extends ItemView {
 
   async onClose() { /* nothing to clean up yet */ }
 
+  onSettingsChanged(): void {
+    this.updatePermissionIcon();
+  }
+
+  private updatePermissionIcon(): void {
+    if (!this.permissionIconEl) return;
+    const mode = this.sessionPermissionOverride ?? this.plugin.settings.permissionMode;
+    this.permissionIconEl.removeClass('obsidibot-perm-readonly', 'obsidibot-perm-standard', 'obsidibot-perm-full');
+    switch (mode) {
+      case 'readonly':
+        setIcon(this.permissionIconEl, 'eye');
+        this.permissionIconEl.title = 'Read-only — no writes or shell commands. Click to change.';
+        this.permissionIconEl.addClass('obsidibot-perm-readonly');
+        break;
+      case 'full':
+        setIcon(this.permissionIconEl, 'triangle-alert');
+        this.permissionIconEl.title = 'Full access — all tools including bash. Click to change.';
+        this.permissionIconEl.addClass('obsidibot-perm-full');
+        break;
+      default:
+        setIcon(this.permissionIconEl, 'shield');
+        this.permissionIconEl.title = 'Standard — files + web, no bash. Click to change.';
+        this.permissionIconEl.addClass('obsidibot-perm-standard');
+    }
+  }
+
   startNewSession() {
     this.sessionPermissionOverride = null;
+    this.updatePermissionIcon();
     this.sessionContextTokens = 0;
     this.tokenGaugeEl.classList.add('obsidibot-hidden');
     this.pendingContexts = [];
@@ -1391,6 +1426,7 @@ export class ClaudeView extends ItemView {
       unlock();
       if (granted) {
         this.sessionPermissionOverride = 'full';
+        this.updatePermissionIcon();
         this.inputEl.value = `[Permission granted] Full access is now enabled. Please retry the blocked ${request.tool} operation and complete the task.`;
       } else {
         this.inputEl.value = `[Permission denied] ${request.tool} access was denied. Please continue without it or suggest an alternative approach.`;
@@ -1418,6 +1454,7 @@ export class ClaudeView extends ItemView {
       });
       upgradeBtn.addEventListener('click', () => {
         this.sessionPermissionOverride = 'full';
+        this.updatePermissionIcon();
         upgradeBtn.setText('↺ retrying…');
         upgradeBtn.disabled = true;
         log('Session permission override set to full');

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -203,13 +203,6 @@ export class ClaudeView extends ItemView {
 
     const inputToolbar = inputArea.createDiv({ cls: 'obsidibot-input-toolbar' });
 
-    this.permissionIconEl = inputToolbar.createEl('button', { cls: 'obsidibot-icon-btn obsidibot-input-toolbar-btn obsidibot-permission-icon' });
-    this.permissionIconEl.addEventListener('click', () => {
-      this.appInternal.setting.open();
-      this.appInternal.setting.openTabById('obsidibot');
-    });
-    this.updatePermissionIcon();
-
     this.attachBtn = inputToolbar.createEl('button', { cls: 'obsidibot-icon-btn obsidibot-input-toolbar-btn' });
     setIcon(this.attachBtn, 'paperclip');
     this.attachBtn.title = 'Attach file or URL';
@@ -219,6 +212,13 @@ export class ClaudeView extends ItemView {
     setIcon(slashBtn, 'slash');
     slashBtn.title = 'Commands';
     slashBtn.addEventListener('click', () => this.openSlashMenu('button'));
+
+    this.permissionIconEl = inputToolbar.createEl('button', { cls: 'obsidibot-icon-btn obsidibot-input-toolbar-btn obsidibot-permission-icon' });
+    this.permissionIconEl.addEventListener('click', () => {
+      this.appInternal.setting.open();
+      this.appInternal.setting.openTabById('obsidibot');
+    });
+    this.updatePermissionIcon();
 
     inputToolbar.createDiv({ cls: 'obsidibot-input-toolbar-spacer' });
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -60,6 +60,8 @@ export interface ObsidiBotSettings {
    * Use "Reload skills" from the palette after adding or removing skill files.
    */
   registerSkillsAsCommands: boolean;
+  /** Keep full access mode between restarts instead of resetting to standard. Default off. */
+  persistFullAccess: boolean;
 }
 
 export const DEFAULT_SETTINGS: ObsidiBotSettings = {
@@ -86,6 +88,7 @@ export const DEFAULT_SETTINGS: ObsidiBotSettings = {
   sessionStoragePath: '',
   commandsFolder: '',
   registerSkillsAsCommands: false,
+  persistFullAccess: false,
 };
 
 export class ObsidiBotSettingsTab extends PluginSettingTab {
@@ -332,8 +335,24 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.permissionMode = value as PermissionMode;
             await this.plugin.saveSettings();
+            this.plugin.notifyPermissionChanged();
+            this.display();
           })
       );
+
+    if (this.plugin.settings.permissionMode === 'full') {
+      new Setting(containerEl)
+        .setName('Persist full access between restarts')
+        .setDesc('When off, full access resets to Standard when Obsidian restarts.')
+        .addToggle((toggle) =>
+          toggle
+            .setValue(this.plugin.settings.persistFullAccess)
+            .onChange(async (value) => {
+              this.plugin.settings.persistFullAccess = value;
+              await this.plugin.saveSettings();
+            })
+        );
+    }
 
     new Setting(containerEl)
       .setName('Show context file setup prompt')

--- a/styles.css
+++ b/styles.css
@@ -117,7 +117,11 @@
 }
 
 .obsidibot-input-toolbar-btn {
-  opacity: 0.4;
+  opacity: 0.65;
+}
+
+.obsidibot-permission-icon {
+  opacity: 1;
 }
 
 .obsidibot-input-toolbar-btn:disabled {

--- a/styles.css
+++ b/styles.css
@@ -1515,14 +1515,21 @@
   color: var(--interactive-accent);
 }
 /* ── Permission mode icon (input toolbar) ── */
-/* Restricted (planned): blue lock */
-.obsidibot-perm-restricted { color: var(--color-blue) !important; }
+/* Hard-coded colors so theme variables can't override them. */
+/* Restricted (planned): blue padlock */
+.obsidibot-perm-restricted .svg-icon { color: #60a5fa !important; stroke: #60a5fa !important; }
 /* Read-only: green eye */
-.obsidibot-perm-readonly { color: var(--color-green) !important; }
+.obsidibot-perm-readonly .svg-icon { color: #4ade80 !important; stroke: #4ade80 !important; }
 /* Standard: yellow shield */
-.obsidibot-perm-standard { color: var(--color-yellow) !important; }
+.obsidibot-perm-standard .svg-icon { color: #facc15 !important; stroke: #facc15 !important; }
 /* Full: red triangle */
-.obsidibot-perm-full { color: var(--color-red) !important; }
+.obsidibot-perm-full .svg-icon { color: #ef4444 !important; stroke: #ef4444 !important; }
+/* Thicker strokes so the icon reads clearly at 14 px */
+.obsidibot-permission-icon .svg-icon path,
+.obsidibot-permission-icon .svg-icon polyline,
+.obsidibot-permission-icon .svg-icon line,
+.obsidibot-permission-icon .svg-icon circle,
+.obsidibot-permission-icon .svg-icon rect { stroke-width: 2.5 !important; }
 
 /* ── Utility ── */
 .obsidibot-invisible { visibility: hidden; }

--- a/styles.css
+++ b/styles.css
@@ -1514,5 +1514,15 @@
   border-color: var(--interactive-accent);
   color: var(--interactive-accent);
 }
+/* ── Permission mode icon (input toolbar) ── */
+/* Restricted (planned): blue lock */
+.obsidibot-perm-restricted { color: var(--color-blue) !important; }
+/* Read-only: green eye */
+.obsidibot-perm-readonly { color: var(--color-green) !important; }
+/* Standard: yellow shield */
+.obsidibot-perm-standard { color: var(--color-yellow) !important; }
+/* Full: red triangle */
+.obsidibot-perm-full { color: var(--color-red) !important; }
+
 /* ── Utility ── */
 .obsidibot-invisible { visibility: hidden; }


### PR DESCRIPTION
## What

Adds a colored status icon to the left of the chat input toolbar that always shows the current effective permission mode.

| Mode | Icon | Color |
|---|---|---|
| Restricted *(planned #154)* | padlock | blue |
| Read-only | eye | green |
| Standard | shield | yellow |
| Full access | triangle-alert | red |

Tooltip describes the mode. Click opens Settings → ObsidiBot.

Also adds a sub-setting under Full access: **Persist full access between restarts** (default off). When off, full mode resets to Standard on the next launch.

Closes #165

## How to test

1. Open the ObsidiBot panel — a yellow shield appears at the far left of the input toolbar (Standard mode).
2. Hover it — tooltip reads "Standard — files + web, no bash. Click to change."
3. Click it — Settings opens to the ObsidiBot tab.
4. Change permission mode to **Read only** — icon updates to green eye.
5. Change to **Full access** — icon updates to red triangle; "Persist full access between restarts" toggle appears directly below.
6. Leave that toggle **off**, close Obsidian, reopen — mode resets to Standard, icon is yellow shield.
7. Set Full access again, enable "Persist full access", restart — mode stays Full.
8. In a session, trigger a permission denial card and click "Allow full access for this session" — icon updates to red triangle immediately.