### PR TITLE
fix: escape special chars in obsidibot-context tag attributes

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -75,6 +75,15 @@ const TOOL_ICONS: Record<string, string> = {
 
 
 
+/** Escape characters that would break pseudo-XML attribute parsing in obsidibot-context tags. */
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 export class ClaudeView extends ItemView {
   plugin: ObsidiBotPlugin;
   private inputEl: HTMLTextAreaElement;
@@ -932,14 +941,14 @@ export class ClaudeView extends ItemView {
       if (isSplit && this.plugin.settings.injectSplitPaneFiles) {
         const paths = leaves.map(l => (l.view as unknown as { file?: { path: string } }).file?.path).filter(Boolean);
         const unique = [...new Set(paths)];
-        activeFileNote = `<obsidibot-context type="split-view" paths="${unique.join('|')}"></obsidibot-context>\n\n`;
+        activeFileNote = `<obsidibot-context type="split-view" paths="${unique.map(p => escapeAttr(p as string)).join('|')}"></obsidibot-context>\n\n`;
       } else if (isStacked && this.plugin.settings.injectStackedTabFiles) {
         const paths = leaves.map(l => (l.view as unknown as { file?: { path: string } }).file?.path).filter(Boolean);
         const unique = [...new Set(paths)];
-        activeFileNote = `<obsidibot-context type="stacked-tabs" paths="${unique.join('|')}"></obsidibot-context>\n\n`;
+        activeFileNote = `<obsidibot-context type="stacked-tabs" paths="${unique.map(p => escapeAttr(p as string)).join('|')}"></obsidibot-context>\n\n`;
       } else {
         const activeFile = this.app.workspace.getActiveFile();
-        activeFileNote = activeFile ? `<obsidibot-context type="active-note" path="${activeFile.path}">Read this file if the user's task relates to its content.</obsidibot-context>\n\n` : '';
+        activeFileNote = activeFile ? `<obsidibot-context type="active-note" path="${escapeAttr(activeFile.path)}">Read this file if the user's task relates to its content.</obsidibot-context>\n\n` : '';
       }
     }
 
@@ -947,9 +956,9 @@ export class ClaudeView extends ItemView {
     if (this.pendingContexts.length > 0) {
       const contextBlock = this.pendingContexts
         .map(c => {
-          if (c.type === 'url') return `<obsidibot-context type="url" url="${c.text}"></obsidibot-context>`;
-          if (c.type === 'image') return `<obsidibot-context type="image" source="${c.source}" path="${c.text}">Read this file to view the image: ${c.text}</obsidibot-context>`;
-          if (c.type === 'pdf') return `<obsidibot-context type="pdf" source="${c.source}" path="${c.text}">Read this file to view the document: ${c.text}</obsidibot-context>`;
+          if (c.type === 'url') return `<obsidibot-context type="url" url="${escapeAttr(c.text)}"></obsidibot-context>`;
+          if (c.type === 'image') return `<obsidibot-context type="image" source="${escapeAttr(c.source)}" path="${escapeAttr(c.text)}">Read this file to view the image: ${c.text}</obsidibot-context>`;
+          if (c.type === 'pdf') return `<obsidibot-context type="pdf" source="${escapeAttr(c.source)}" path="${escapeAttr(c.text)}">Read this file to view the document: ${c.text}</obsidibot-context>`;
           return `<obsidibot-context type="attachment" source="${c.source}">${neutralizeTriggers(c.text)}</obsidibot-context>`;
         })
         .join('\n\n');

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -140,6 +140,17 @@ export interface ChatMessage {
   contexts?: InjectedContext[];
 }
 
+/** Reverse of ClaudeView's escapeAttr — decode HTML entities in context tag attribute values. */
+function decodeAttr(value: string): string {
+  return value.replace(/&(?:amp|quot|lt|gt);/g, (entity) => {
+    if (entity === '&amp;')  return '&';
+    if (entity === '&quot;') return '"';
+    if (entity === '&lt;')   return '<';
+    if (entity === '&gt;')   return '>';
+    return entity;
+  });
+}
+
 /**
  * Strip all <obsidibot-context> tags from content and return the clean text
  * plus a structured list of the injected contexts for badge rendering on replay.
@@ -155,7 +166,7 @@ function extractObsidiBotContexts(content: string): { clean: string; contexts: I
     let m: RegExpExecArray | null;
     ATTR_RE.lastIndex = 0;
     while ((m = ATTR_RE.exec(attrStr)) !== null) {
-      ctx[m[1]] = m[2];
+      ctx[m[1]] = decodeAttr(m[2]);
     }
     if (body.trim()) ctx['content'] = body.trim();
     if (ctx['type']) contexts.push(ctx as unknown as InjectedContext);


### PR DESCRIPTION
## What

File paths containing `"`, `<`, or `>` (valid characters in macOS/Linux filenames) were interpolated directly into pseudo-XML attribute values inside `obsidibot-context` tags. This silently corrupted context injection on session replay — the tag regex would terminate early, dropping or misattributing the injected context.

## Why it breaks

Two regexes parse stored context tags:
- `TAG_RE` uses `[^>]*` to capture the attribute string — any `>` in a path value terminates it early, breaking the whole tag
- `ATTR_RE` uses `"([^"]*)"` to capture attribute values — any `"` in a path terminates it early, silently truncating the value

On Windows these characters are illegal in filenames, so the bug is latent there. On macOS/Linux it's a real hazard.

## Changes

**`src/ClaudeView.ts`** — adds `escapeAttr()` (escapes `&`, `"`, `<`, `>` in that order) and applies it to all six attribute-value interpolation sites:
- `active-note` path
- `split-view` and `stacked-tabs` paths (each path in the `|`-joined list)
- `url` url
- `image` source and path
- `pdf` source and path

**`src/utils/sessionStorage.ts`** — adds `decodeAttr()` (single-pass entity decode) and applies it when storing each parsed attribute value in `extractObsidiBotContexts`, so context badges on session replay show the original unescaped path.

## Testing

macOS or Linux only (Windows filenames can't contain these characters):

1. Create a note with a `"` in its name, e.g. `He said "hello".md`
2. Open it in Obsidian so it is the active file
3. Send any message to ObsidiBot — the active-note context tag should be injected cleanly
4. Start a new session and reload the old one — the context badge on the sent message should display the correct filename, not a truncated or blank path
5. Repeat with a note whose name contains `<` or `>`
6. Attach the same file as an image/PDF attachment and verify the badge survives session reload

URL context: paste a URL containing `"` (e.g., a query string like `?q="foo"`) into the attachment area and verify the url badge round-trips correctly.