### PR TITLE
fix: make resolveShellEnv async to avoid blocking Obsidian at load

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -58,7 +58,7 @@ export default class ObsidiBotPlugin extends Plugin {
       })
     );
 
-    this.shellEnv = resolveShellEnv();
+    void resolveShellEnv().then(env => { this.shellEnv = env; });
     this.claudeBinaryPath = findClaudeBinary(this.settings.binaryPath);
 
     if (!this.claudeBinaryPath) {

--- a/src/utils/shellEnv.ts
+++ b/src/utils/shellEnv.ts
@@ -1,30 +1,30 @@
-import { execSync } from 'child_process';
+import { exec } from 'child_process';
 
-export function resolveShellEnv(): Record<string, string> {
+export function resolveShellEnv(): Promise<Record<string, string>> {
   // On Windows, skip shell resolution and use process.env directly.
   // The full shell env is not needed on Windows — PATH and relevant vars
   // are already present in process.env via Obsidian's launch environment.
   if (process.platform === 'win32') {
-    return { ...process.env };
+    return Promise.resolve({ ...process.env } as Record<string, string>);
   }
 
-  // On Mac/Linux, launch a login shell to pick up PATH from .zshrc / .bash_profile
-  try {
+  // On Mac/Linux, launch a login shell to pick up PATH from .zshrc / .bash_profile.
+  // Uses exec (async) so the Obsidian event loop is never blocked.
+  return new Promise((resolve) => {
     const shell = process.env.SHELL || '/bin/bash';
-    const output = execSync(`${shell} -l -c env`, {
-      encoding: 'utf8',
-      timeout: 5000,
-    });
-
-    const env: Record<string, string> = {};
-    for (const line of output.split('\n')) {
-      const idx = line.indexOf('=');
-      if (idx > 0) {
-        env[line.substring(0, idx)] = line.substring(idx + 1);
+    exec(`${shell} -l -c env`, { encoding: 'utf8', timeout: 5000 }, (err, stdout) => {
+      if (err) {
+        resolve({ ...process.env } as Record<string, string>);
+        return;
       }
-    }
-    return env;
-  } catch {
-    return { ...process.env };
-  }
+      const env: Record<string, string> = {};
+      for (const line of stdout.split('\n')) {
+        const idx = line.indexOf('=');
+        if (idx > 0) {
+          env[line.substring(0, idx)] = line.substring(idx + 1);
+        }
+      }
+      resolve(env);
+    });
+  });
 }


### PR DESCRIPTION
## What

`resolveShellEnv()` called `execSync` to launch a login shell (`zsh -l -c env` / `bash -l -c env`) to pick up PATH on Mac/Linux. `execSync` blocks the Node event loop synchronously — Obsidian froze entirely (no rendering, no input) for up to 5 seconds on machines with slow shell startup (NVM, Conda, network-mounted home directories, complex `.zshrc`).

## Change

**`src/utils/shellEnv.ts`** — replaces `execSync` with `exec` (callback-based), wrapped in a `Promise`. Same 5-second timeout. Same fallback to `process.env` on error. On Windows the function returns `Promise.resolve(process.env)` immediately — no behavioural change there.

**`main.ts`** — fires the promise at the start of `onload()` and settles the result back into `this.shellEnv` via `.then()`:

```typescript
void resolveShellEnv().then(env => { this.shellEnv = env; });
```

`this.shellEnv` stays typed as `Record<string, string>` (initialised to `{}`). No call sites in `ClaudeView.ts` need updating. The event loop is never blocked.

## Race window

Between plugin load and promise resolution (up to ~5s on Mac/Linux), `shellEnv` is `{}`. A spawn fired during that window would get an empty env. In practice this cannot happen — the user cannot open the panel, type, and send within 5 seconds of a cold Obsidian launch. If it did, `spawnClaude`'s existing error handling surfaces a notice.

Awaiting the promise at individual call sites (`compactSession`, `handleVaultInject`, etc.) is the more rigorous fix but requires making those methods async — that belongs in the God-class refactor (#5), not here.

## Testing

Windows: behaviour is unchanged (returns immediately). Mac/Linux needed — see issue #186.