### PR TITLE
fix: use sparse sort order in saveSessionAtTop to avoid O(n) file writes

### DIFF
--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -87,18 +87,15 @@ export function loadAllSessions(vaultRoot: string, sessionsDir: string, configDi
 
 /**
  * Save a new session at the top of the ordered list.
- * If any existing sessions have a sortOrder, the new session gets sortOrder=0
- * and all others are shifted down by 1. Otherwise just saves normally.
+ * If any existing sessions have a sortOrder, the new session gets sortOrder = min - 1
+ * so it sorts first without rewriting any other session files.
  */
 export function saveSessionAtTop(vaultRoot: string, session: StoredSession, sessionsDir: string, configDir: string): void {
   const existing = loadAllSessions(vaultRoot, sessionsDir, configDir);
-  const anyOrdered = existing.some(s => s.sortOrder !== undefined);
-  if (anyOrdered) {
-    existing.forEach(s => {
-      s.sortOrder = (s.sortOrder ?? 0) + 1;
-      writeFileSync(join(sessionsDir, `${s.id}.json`), JSON.stringify(s, null, 2));
-    });
-    session.sortOrder = 0;
+  const ordered = existing.filter(s => s.sortOrder !== undefined);
+  if (ordered.length > 0) {
+    const minOrder = Math.min(...ordered.map(s => s.sortOrder as number));
+    session.sortOrder = minOrder - 1;
   }
   saveSession(vaultRoot, session, sessionsDir);
 }


### PR DESCRIPTION
## What

Every time a new session was created, `saveSessionAtTop` rewrote **every existing session file** synchronously to bump each `sortOrder` by 1. With 50 sessions this is 50 `writeFileSync` calls in a tight loop on the main thread.

## Fix

New session gets `sortOrder = (minimum existing sortOrder) - 1`. It sorts first in the ascending `a.sortOrder - b.sortOrder` comparison without touching any other file. Only the new session is written.

Sort numbers drift negative over time, but `SessionListModal.saveSortOrder` normalises everything back to `0, 1, 2…` whenever the user manually reorders via drag-and-drop — so the drift is bounded.

If no sessions have `sortOrder` yet (nobody has reordered), the block is skipped and the new session uses the existing date-based fallback sort, which already places it first by `updatedAt`.

## Testing

1. Create several sessions and manually reorder them via drag-and-drop in the session manager
2. Create a new session — it should appear at the top of the list
3. Inspect the session JSON files: only the new session file should have a timestamp newer than the reorder
4. Repeat several times and verify the list stays correctly ordered (new sessions always at top, manual order preserved below)