### PR TITLE
chore: deduplicate getVaultRoot and fix ATTR_RE matchAll

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -25,7 +25,7 @@ export default class ObsidiBotPlugin extends Plugin {
   claudeBinaryPath: string | null = null;
   private skillCommandIds = new Set<string>();
 
-  private getVaultRoot(): string {
+  getVaultRoot(): string {
     return (this.app.vault.adapter as unknown as { basePath: string }).basePath;
   }
 

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -125,9 +125,6 @@ export class ClaudeView extends ItemView {
     this.plugin = plugin;
   }
 
-  private getVaultRoot(): string {
-    return (this.app.vault.adapter as unknown as { basePath: string }).basePath;
-  }
 
   private get appInternal(): AppInternal {
     return this.app as unknown as AppInternal;
@@ -368,7 +365,7 @@ export class ClaudeView extends ItemView {
     }
 
     if (this.plugin.settings.resumeLastSession) {
-      const vaultRoot = this.getVaultRoot();
+      const vaultRoot = this.plugin.getVaultRoot();
       const sessions = loadAllSessions(vaultRoot, this.getSessionsDir(), this.app.vault.configDir);
       if (sessions.length > 0) {
         const lastId = this.plugin.settings.lastActiveSessionId;
@@ -390,7 +387,7 @@ export class ClaudeView extends ItemView {
       !this.plugin.settings.skipContextFilePrompt &&
       !this.app.vault.getFileByPath(this.plugin.settings.contextFilePath)
     ) {
-      const vaultRoot = this.getVaultRoot();
+      const vaultRoot = this.plugin.getVaultRoot();
       new ContextGenerationModal(
         this.app,
         this.plugin,
@@ -453,7 +450,7 @@ export class ClaudeView extends ItemView {
     this.tokenGaugeEl.classList.add('obsidibot-hidden');
     this.pendingContexts = [];
     this.renderContextZone();
-    const vaultRoot = this.getVaultRoot();
+    const vaultRoot = this.plugin.getVaultRoot();
     const now = new Date().toISOString();
     const sessionId = now.replace(/[:.]/g, '-');
 
@@ -481,7 +478,7 @@ export class ClaudeView extends ItemView {
   }
 
   showSessionHistory() {
-    const vaultRoot = this.getVaultRoot();
+    const vaultRoot = this.plugin.getVaultRoot();
     const sessionsDir = this.getSessionsDir();
     const sessions = loadAllSessions(vaultRoot, sessionsDir, this.app.vault.configDir);
     new SessionListModal(this.app, vaultRoot, sessions, (session) => {
@@ -757,7 +754,7 @@ export class ClaudeView extends ItemView {
         const proc = spawnClaude({
           binaryPath: this.plugin.claudeBinaryPath,
           prompt,
-          vaultRoot: this.getVaultRoot(),
+          vaultRoot: this.plugin.getVaultRoot(),
           env: this.plugin.shellEnv,
           permissionMode: 'readonly',
         });
@@ -999,7 +996,7 @@ export class ClaudeView extends ItemView {
       proc = spawnClaude({
         binaryPath: this.plugin.claudeBinaryPath,
         prompt: finalPrompt,
-        vaultRoot: this.getVaultRoot(),
+        vaultRoot: this.plugin.getVaultRoot(),
         env: this.plugin.shellEnv,
         resumeSessionId: this.currentSessionId,
         permissionMode: this.sessionPermissionOverride ?? this.plugin.settings.permissionMode,
@@ -1100,7 +1097,7 @@ export class ClaudeView extends ItemView {
         if (!clean) this.appendMessage('system', 'Interrupted.');
 
         if (sessionId) {
-          const vaultRoot = this.getVaultRoot();
+          const vaultRoot = this.plugin.getVaultRoot();
           const sessionsDir = this.getSessionsDir();
           const now = new Date().toISOString();
 
@@ -1282,7 +1279,7 @@ export class ClaudeView extends ItemView {
     body.createEl('p', { cls: 'obsidibot-welcome-tip', text: tip });
 
     // Recent sessions footer
-    const sessions = loadAllSessions(this.getVaultRoot(), this.getSessionsDir(), this.app.vault.configDir)
+    const sessions = loadAllSessions(this.plugin.getVaultRoot(), this.getSessionsDir(), this.app.vault.configDir)
       .filter(s => s.id !== this.currentSessionFileId);
     if (sessions.length > 0) {
       const recent = welcome.createDiv({ cls: 'obsidibot-welcome-recent' });
@@ -1675,7 +1672,7 @@ export class ClaudeView extends ItemView {
     const proc = spawnClaude({
       binaryPath: this.plugin.claudeBinaryPath,
       prompt: '/compact',
-      vaultRoot: this.getVaultRoot(),
+      vaultRoot: this.plugin.getVaultRoot(),
       env: this.plugin.shellEnv,
       resumeSessionId: sessionId,
       permissionMode: this.sessionPermissionOverride ?? this.plugin.settings.permissionMode,
@@ -1824,7 +1821,7 @@ export class ClaudeView extends ItemView {
   }
 
   private saveBinaryToTmp(filename: string, data: ArrayBuffer): string {
-    const vaultRoot = this.getVaultRoot();
+    const vaultRoot = this.plugin.getVaultRoot();
     const tmpDir = join(vaultRoot, this.app.vault.configDir, 'plugins', 'obsidibot', 'tmp');
     if (!existsSync(tmpDir)) mkdirSync(tmpDir, { recursive: true });
     const filePath = join(tmpDir, filename);
@@ -1909,7 +1906,7 @@ export class ClaudeView extends ItemView {
       proc = spawnClaude({
         binaryPath: this.plugin.claudeBinaryPath,
         prompt: injectPrompt,
-        vaultRoot: this.getVaultRoot(),
+        vaultRoot: this.plugin.getVaultRoot(),
         env: this.plugin.shellEnv,
         resumeSessionId: this.currentSessionId,
         permissionMode: this.sessionPermissionOverride ?? this.plugin.settings.permissionMode,
@@ -2020,7 +2017,7 @@ export class ClaudeView extends ItemView {
         if (!clean) this.appendMessage('system', 'Interrupted.');
 
         if (sessionId && this.currentSessionId) {
-          const vaultRoot = this.getVaultRoot();
+          const vaultRoot = this.plugin.getVaultRoot();
           const now = new Date().toISOString();
           const fileId = this.currentSessionFileId ?? this.currentSessionId;
           saveSession(vaultRoot, {
@@ -2122,7 +2119,7 @@ export class ClaudeView extends ItemView {
 
   /** Resolved sessions directory, honoring the user's sessionStoragePath setting. */
   private getSessionsDir(): string {
-    const vaultRoot = this.getVaultRoot();
+    const vaultRoot = this.plugin.getVaultRoot();
     return resolveSessionsDir(vaultRoot, this.plugin.settings.sessionStoragePath, this.app.vault.configDir);
   }
 
@@ -2285,7 +2282,7 @@ export class ClaudeView extends ItemView {
   }
 
   private resolveCommandsFolder(): string {
-    const vaultRoot = this.getVaultRoot();
+    const vaultRoot = this.plugin.getVaultRoot();
     const custom = this.plugin.settings.commandsFolder;
     if (custom?.trim()) {
       const p = custom.trim();
@@ -2447,7 +2444,7 @@ export class ClaudeView extends ItemView {
         description: 'Save this session to your vault',
         action: () => {
           if (!this.currentSessionFileId) { new Notice('No active session to export.'); return; }
-          const sessions = loadAllSessions(this.getVaultRoot(), this.getSessionsDir(), this.app.vault.configDir);
+          const sessions = loadAllSessions(this.plugin.getVaultRoot(), this.getSessionsDir(), this.app.vault.configDir);
           const session = sessions.find(s => s.id === this.currentSessionFileId);
           if (session) void this.exportSessionToVault(session);
           else new Notice('Session not found.');

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -156,13 +156,10 @@ function extractObsidiBotContexts(content: string): { clean: string; contexts: I
   const contexts: InjectedContext[] = [];
   // Matches both self-closing-style and body-carrying tags
   const TAG_RE = /<obsidibot-context\s([^>]*)>([\s\S]*?)<\/obsidibot-context>/g;
-  const ATTR_RE = /(\w[\w-]*)="([^"]*)"/g;
 
   const clean = content.replace(TAG_RE, (_match, attrStr: string, body: string) => {
     const ctx: Record<string, string> = {};
-    let m: RegExpExecArray | null;
-    ATTR_RE.lastIndex = 0;
-    while ((m = ATTR_RE.exec(attrStr)) !== null) {
+    for (const m of attrStr.matchAll(/(\w[\w-]*)="([^"]*)"/g)) {
       ctx[m[1]] = decodeAttr(m[2]);
     }
     if (body.trim()) ctx['content'] = body.trim();


### PR DESCRIPTION
## What

Two maintenance fixes bundled together (code-review items #7 and #15):

**#7 — `getVaultRoot()` duplicated across `main.ts` / `ClaudeView.ts`**

`ClaudeView` had its own private `getVaultRoot()` that was identical to the one on the plugin class. Removed the duplicate, made `ObsidiBotPlugin.getVaultRoot()` public, and updated all 15 call sites in `ClaudeView.ts` to delegate to `this.plugin.getVaultRoot()`.

**#15 — `ATTR_RE` global-flag regex reused inside a loop**

`extractObsidiBotContexts` in `sessionStorage.ts` used a module-level global-flag regex and manually reset `lastIndex = 0` before each call. Any early return or exception would leave `lastIndex` stale, causing silent attribute-parse failures on the next call. Replaced with `String.prototype.matchAll()`, which creates a fresh stateful iterator each time.

## Testing

- Open a session with context badges (active note, split pane, stacked tabs, attachment, URL, image, PDF) and confirm badges render correctly on session reload — exercises the `matchAll` path through `extractObsidiBotContexts`.
- No behaviour change expected for `getVaultRoot` — pure delegation refactor.