### PR TITLE
fix: use env -0 to preserve multi-line env var values

### DIFF
--- a/src/utils/shellEnv.ts
+++ b/src/utils/shellEnv.ts
@@ -12,16 +12,18 @@ export function resolveShellEnv(): Promise<Record<string, string>> {
   // Uses exec (async) so the Obsidian event loop is never blocked.
   return new Promise((resolve) => {
     const shell = process.env.SHELL || '/bin/bash';
-    exec(`${shell} -l -c env`, { encoding: 'utf8', timeout: 5000 }, (err, stdout) => {
+    // env -0 outputs null-terminated entries, preserving values that contain newlines
+    // (exported PEM keys, multi-line PS1, etc.). Supported on Linux and macOS 10.15+.
+    exec(`${shell} -l -c 'env -0'`, { encoding: 'utf8', timeout: 5000 }, (err, stdout) => {
       if (err) {
         resolve({ ...process.env } as Record<string, string>);
         return;
       }
       const env: Record<string, string> = {};
-      for (const line of stdout.split('\n')) {
-        const idx = line.indexOf('=');
+      for (const entry of stdout.split('\0')) {
+        const idx = entry.indexOf('=');
         if (idx > 0) {
-          env[line.substring(0, idx)] = line.substring(idx + 1);
+          env[entry.substring(0, idx)] = entry.substring(idx + 1);
         }
       }
       resolve(env);


### PR DESCRIPTION
## What

Code-review item #12.

`resolveShellEnv` split the `env` command output on newlines. Any env var whose value contains a newline (e.g. multi-line `PS1`, `LS_COLORS`, shell functions exported via `export -f`) would be silently split into two broken entries, corrupting the environment passed to spawned Claude processes.

Fix: pass `-0` to `env` so values are delimited by NUL bytes instead of newlines, then split on `\0`.

`env -0` is supported on macOS 10.15+ (Catalina) which is the minimum for Obsidian 1.x, and on all modern Linux distributions.

## Testing

Mac/Linux only — Windows takes a fast path that skips `resolveShellEnv` entirely.

- Temporarily add `export MULTILINE_TEST=$'line1\nline2'` to `~/.zshrc` or `~/.bash_profile`.
- Open ObsidiBot, start a chat, and ask Claude to echo that variable via a shell tool.
- Confirm the value is `line1\nline2` (not truncated at `line1`).
- Confirm normal chat still works end-to-end.

> **Note:** this path is Mac/Linux only and the multi-line case is rare in practice. If you can't test on Mac/Linux, merging and watching for regressions in normal usage is low-risk.