### PR TITLE
feat: add configurable canvas size guard

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1590,7 +1590,7 @@ export class ClaudeView extends ItemView {
     }
 
     const raw = await this.app.vault.read(file);
-    const content = file.extension === 'canvas' ? canvasToText(file.name, raw) : raw;
+    const content = file.extension === 'canvas' ? canvasToText(file.name, raw, this.plugin.settings.canvasMaxChars) : raw;
     this.injectSelectionContext(content, file.basename);
   }
 
@@ -1730,7 +1730,7 @@ export class ClaudeView extends ItemView {
         this.pendingContexts.push({ text: filePath, source: f.name, pinned: false, type });
       } else {
         let text = TEXT_EXTS.has(ext) ? await f.text() : f.name;
-        if (ext === 'canvas') text = canvasToText(f.name, text);
+        if (ext === 'canvas') text = canvasToText(f.name, text, this.plugin.settings.canvasMaxChars);
         this.pendingContexts.push({ text, source: f.name, pinned: false });
       }
       this.renderContextZone();
@@ -1812,7 +1812,7 @@ export class ClaudeView extends ItemView {
         this.pendingContexts.push({ text: filePath, source: f.name, pinned: false, type });
       } else if (TEXT_EXTS.has(ext)) {
         let text = await f.text();
-        if (ext === 'canvas') text = canvasToText(f.name, text);
+        if (ext === 'canvas') text = canvasToText(f.name, text, this.plugin.settings.canvasMaxChars);
         this.pendingContexts.push({ text, source: f.name, pinned: false });
       } else {
         // Unknown binary — pass filename; Claude can attempt to read it

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,6 +62,8 @@ export interface ObsidiBotSettings {
   registerSkillsAsCommands: boolean;
   /** Keep full access mode between restarts instead of resetting to standard. Default off. */
   persistFullAccess: boolean;
+  /** Max characters of canvas text injected as context. 0 = no limit. */
+  canvasMaxChars: number;
 }
 
 export const DEFAULT_SETTINGS: ObsidiBotSettings = {
@@ -89,6 +91,7 @@ export const DEFAULT_SETTINGS: ObsidiBotSettings = {
   commandsFolder: '',
   registerSkillsAsCommands: false,
   persistFullAccess: false,
+  canvasMaxChars: 50000,
 };
 
 export class ObsidiBotSettingsTab extends PluginSettingTab {
@@ -245,6 +248,20 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.injectStackedTabFiles)
           .onChange(async (value) => {
             this.plugin.settings.injectStackedTabFiles = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Max canvas size (characters)')
+      .setDesc('Canvas files converted to text and injected as context will be truncated at this character limit. Set to 0 for no limit.')
+      .addText((text) =>
+        text
+          .setPlaceholder('50000')
+          .setValue(String(this.plugin.settings.canvasMaxChars))
+          .onChange(async (value) => {
+            const n = parseInt(value, 10);
+            this.plugin.settings.canvasMaxChars = isNaN(n) || n < 0 ? 0 : n;
             await this.plugin.saveSettings();
           })
       );

--- a/src/utils/canvasParser.ts
+++ b/src/utils/canvasParser.ts
@@ -45,7 +45,7 @@ function nodeLabel(node: CanvasNode): string {
   }
 }
 
-export function canvasToText(filename: string, json: string): string {
+export function canvasToText(filename: string, json: string, maxChars = 0): string {
   let data: CanvasData;
   try {
     data = JSON.parse(json) as CanvasData;
@@ -117,5 +117,9 @@ export function canvasToText(filename: string, json: string): string {
 
   lines.push('', `(${nodes.length} node${nodes.length !== 1 ? 's' : ''}, ${edges.length} connection${edges.length !== 1 ? 's' : ''})`);
 
-  return lines.join('\n');
+  const result = lines.join('\n');
+  if (maxChars > 0 && result.length > maxChars) {
+    return result.substring(0, maxChars) + `\n\n[Canvas truncated — ${nodes.length} nodes exceeded the ${maxChars}-character limit. Adjust "Max canvas size" in ObsidiBot settings to see more.]`;
+  }
+  return result;
 }


### PR DESCRIPTION
## What

Code-review item #13.

Canvas files are converted to human-readable text before being injected as context. A very large canvas (hundreds of nodes, dense text cards) could silently flood the context window.

This adds a user-facing setting **"Max canvas size (characters)"** (default: 50 000, 0 = no limit) under the context-injection section of ObsidiBot settings. When the converted text exceeds the limit, it is truncated and a notice is appended:

```
[Canvas truncated — N nodes exceeded the X-character limit. Adjust "Max canvas size" in ObsidiBot settings to see more.]
```

The limit applies to all three canvas injection paths: active-note inject, file-picker attach, and clipboard/drag-drop attach.

## Files changed

- `src/settings.ts` — `canvasMaxChars` field, default (50 000), and settings UI
- `src/utils/canvasParser.ts` — `maxChars` parameter + truncation logic
- `src/ClaudeView.ts` — all 3 `canvasToText()` call sites pass `this.plugin.settings.canvasMaxChars`

## Testing

- Create a canvas with a few text nodes and confirm it injects normally.
- Set "Max canvas size" to a small value (e.g. 100) and attach a canvas — verify the truncation notice appears in the injected text Claude receives.
- Set to 0 and confirm no truncation occurs regardless of canvas size.