### PR TITLE
chore: fix ESLint violations introduced by recent changes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -487,6 +487,7 @@ export default class ObsidiBotPlugin extends Plugin {
       for (const cmd of commands) {
         const prefix = cmd.id.includes(':') ? cmd.id.split(':')[0] : 'core';
         if (!groups.has(prefix)) groups.set(prefix, []);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         groups.get(prefix)!.push(cmd);
       }
 

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -938,13 +938,13 @@ export class ClaudeView extends ItemView {
       const isStacked = !isSplit && leaves.length > 1;
 
       if (isSplit && this.plugin.settings.injectSplitPaneFiles) {
-        const paths = leaves.map(l => (l.view as unknown as { file?: { path: string } }).file?.path).filter(Boolean);
+        const paths = leaves.map(l => (l.view as unknown as { file?: { path: string } }).file?.path).filter((p): p is string => p !== undefined);
         const unique = [...new Set(paths)];
-        activeFileNote = `<obsidibot-context type="split-view" paths="${unique.map(p => escapeAttr(p as string)).join('|')}"></obsidibot-context>\n\n`;
+        activeFileNote = `<obsidibot-context type="split-view" paths="${unique.map(p => escapeAttr(p)).join('|')}"></obsidibot-context>\n\n`;
       } else if (isStacked && this.plugin.settings.injectStackedTabFiles) {
-        const paths = leaves.map(l => (l.view as unknown as { file?: { path: string } }).file?.path).filter(Boolean);
+        const paths = leaves.map(l => (l.view as unknown as { file?: { path: string } }).file?.path).filter((p): p is string => p !== undefined);
         const unique = [...new Set(paths)];
-        activeFileNote = `<obsidibot-context type="stacked-tabs" paths="${unique.map(p => escapeAttr(p as string)).join('|')}"></obsidibot-context>\n\n`;
+        activeFileNote = `<obsidibot-context type="stacked-tabs" paths="${unique.map(p => escapeAttr(p)).join('|')}"></obsidibot-context>\n\n`;
       } else {
         const activeFile = this.app.workspace.getActiveFile();
         activeFileNote = activeFile ? `<obsidibot-context type="active-note" path="${escapeAttr(activeFile.path)}">Read this file if the user's task relates to its content.</obsidibot-context>\n\n` : '';

--- a/src/modals/MemoryAuditModal.ts
+++ b/src/modals/MemoryAuditModal.ts
@@ -18,10 +18,10 @@ export class MemoryAuditModal extends Modal {
     const btnRow = this.contentEl.createDiv({ cls: 'obsidibot-audit-btn-row' });
 
     btnRow.createEl('button', { text: 'Open file' })
-      .addEventListener('click', async () => {
+      .addEventListener('click', () => {
         this.close();
         const file = this._app.vault.getFileByPath(this.plugin.settings.contextFilePath);
-        if (file) await this._app.workspace.getLeaf(false).openFile(file);
+        if (file) void this._app.workspace.getLeaf(false).openFile(file);
       });
 
     btnRow.createEl('button', { cls: 'mod-cta', text: 'Audit with Claude' })

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -343,7 +343,7 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
     if (this.plugin.settings.permissionMode === 'full') {
       new Setting(containerEl)
         .setName('Persist full access between restarts')
-        .setDesc('When off, full access resets to Standard when Obsidian restarts.')
+        .setDesc('When off, full access resets to standard when Obsidian restarts.')
         .addToggle((toggle) =>
           toggle
             .setValue(this.plugin.settings.persistFullAccess)

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -94,7 +94,7 @@ export function saveSessionAtTop(vaultRoot: string, session: StoredSession, sess
   const existing = loadAllSessions(vaultRoot, sessionsDir, configDir);
   const ordered = existing.filter(s => s.sortOrder !== undefined);
   if (ordered.length > 0) {
-    const minOrder = Math.min(...ordered.map(s => s.sortOrder as number));
+    const minOrder = Math.min(...ordered.map(s => s.sortOrder));
     session.sortOrder = minOrder - 1;
   }
   saveSession(vaultRoot, session, sessionsDir);

--- a/src/utils/shellEnv.ts
+++ b/src/utils/shellEnv.ts
@@ -14,7 +14,7 @@ export function resolveShellEnv(): Promise<Record<string, string>> {
     const shell = process.env.SHELL || '/bin/bash';
     exec(`${shell} -l -c env`, { encoding: 'utf8', timeout: 5000 }, (err, stdout) => {
       if (err) {
-        resolve({ ...process.env } as Record<string, string>);
+        resolve({ ...process.env });
         return;
       }
       const env: Record<string, string> = {};


### PR DESCRIPTION
## Summary

Cleans up lint errors surfaced after the recent security and correctness fixes added new code patterns.

- `sessionStorage.ts`, `shellEnv.ts` — remove unnecessary type assertions (no `strictNullChecks`)
- `ClaudeView.ts` — replace `filter(Boolean)` + `as string` cast with a proper type predicate `filter((p): p is string => p !== undefined)`, correctly narrowing the type without a cast
- `MemoryAuditModal.ts` — fix `no-misused-promises`: remove `async` from `addEventListener` callback, use `void` to discard the file-open promise
- `settings.ts` — lowercase "standard" in prose description (not a label, just an adjective)
- `main.ts` — restore `!` non-null assertion after `Map.has()` check with `eslint-disable` comment; assertion is logically required even though ESLint considers it redundant without strict null checks