### PR TITLE
fix: permission icon stays stale after changing settings

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,7 @@ import { writeFileSync, existsSync, readdirSync } from 'fs';
 import { join, isAbsolute } from 'path';
 import { ClaudeView, VIEW_TYPE_CLAUDE } from './src/ClaudeView';
 import { ObsidiBotSettings, DEFAULT_SETTINGS, ObsidiBotSettingsTab } from './src/settings';
-import { findClaudeBinary } from './src/ClaudeProcess';
+import { findClaudeBinary, PermissionMode } from './src/ClaudeProcess';
 import { resolveShellEnv } from './src/utils/shellEnv';
 import { initLogger, log, warn } from './src/utils/logger';
 import { AboutModal } from './src/modals/AboutModal';
@@ -391,6 +391,12 @@ export default class ObsidiBotPlugin extends Plugin {
   notifyPermissionChanged(): void {
     const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDE);
     if (leaves.length) (leaves[0].view as ClaudeView).onSettingsChanged();
+  }
+
+  getEffectivePermissionMode(): PermissionMode {
+    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDE);
+    if (leaves.length) return (leaves[0].view as ClaudeView).getEffectivePermissionMode();
+    return this.settings.permissionMode;
   }
 
   private showMemoryUpdateNotice(): void {

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -402,6 +402,10 @@ export class ClaudeView extends ItemView {
 
   async onClose() { /* nothing to clean up yet */ }
 
+  getEffectivePermissionMode(): PermissionMode {
+    return this.sessionPermissionOverride ?? this.plugin.settings.permissionMode;
+  }
+
   onSettingsChanged(): void {
     this.sessionPermissionOverride = null;
     this.updatePermissionIcon();

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -403,6 +403,7 @@ export class ClaudeView extends ItemView {
   async onClose() { /* nothing to clean up yet */ }
 
   onSettingsChanged(): void {
+    this.sessionPermissionOverride = null;
     this.updatePermissionIcon();
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -348,7 +348,7 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
           .addOption('standard', 'Standard — files + web, no bash (recommended)')
           .addOption('readonly', 'Read only — no writes or shell commands')
           .addOption('full', 'Full access — everything including bash')
-          .setValue(this.plugin.settings.permissionMode)
+          .setValue(this.plugin.getEffectivePermissionMode())
           .onChange(async (value) => {
             this.plugin.settings.permissionMode = value as PermissionMode;
             await this.plugin.saveSettings();
@@ -357,7 +357,7 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
           })
       );
 
-    if (this.plugin.settings.permissionMode === 'full') {
+    if (this.plugin.getEffectivePermissionMode() === 'full') {
       new Setting(containerEl)
         .setName('Persist full access between restarts')
         .setDesc('When off, full access resets to standard when Obsidian restarts.')


### PR DESCRIPTION
## Summary

- After granting full access mid-session, the permission icon correctly showed the warning triangle but the settings dropdown still displayed \"Standard\" — the session override was invisible to settings
- Separately, changing the permission in settings did not update the icon (session override persisted and kept winning)

**Root cause (icon stale):** `onSettingsChanged()` called `updatePermissionIcon()` without first clearing `sessionPermissionOverride`, so the override kept winning over the new setting.

**Root cause (settings shows wrong value):** Settings dropdown read `plugin.settings.permissionMode` directly, with no awareness of the session override.

## Changes

- `onSettingsChanged()` now clears `sessionPermissionOverride` before updating the icon — an explicit settings change always wins
- Added `getEffectivePermissionMode()` on `ClaudeView` and a plugin-level wrapper; settings dropdown and \"Persist full access\" toggle now read the effective mode so they reflect the actual active state

## Test plan

- [ ] Open ObsidiBot. Confirm the icon shows the shield (Standard mode) and settings shows Standard.
- [ ] Trigger a permission denial (ask Claude to run a bash command in Standard mode). Denial card appears.
- [ ] Click **Allow full access for this session**. Icon changes to red triangle-alert.
- [ ] Click the red triangle to open settings. **Expected:** dropdown shows Full Access (not Standard).
- [ ] Change the dropdown to Standard and close settings. **Expected:** icon immediately updates to shield.
- [ ] Reopen settings. **Expected:** dropdown shows Standard.
- [ ] Bonus: switching settings *to* Full shows the red triangle and the Persist toggle appears.