### PR TITLE
fix: notify Claude of permission mode change mid-session

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -19,7 +19,7 @@ import { spawnClaude, parseStreamOutput, killProcess, findClaudeBinary, Permissi
 import { extractActions, executeAction, promptPermissionRequest } from './UIBridge';
 import { VaultQuery, VaultQueryResult, resolveQuery, queryLabel, buildInjectMessage } from './QueryHandler';
 import { QUERY_PREFIX, neutralizeTriggers } from './constants';
-import { ContextManager } from './ContextManager';
+import { ContextManager, PERMISSION_DESCRIPTIONS } from './ContextManager';
 import { log, estimateTokens } from './utils/logger';
 import { extractToolDetail } from './utils/toolFormatting';
 import {
@@ -411,6 +411,13 @@ export class ClaudeView extends ItemView {
   onSettingsChanged(): void {
     this.sessionPermissionOverride = null;
     this.updatePermissionIcon();
+    if (this.currentSessionId) {
+      const perm = PERMISSION_DESCRIPTIONS[this.plugin.settings.permissionMode];
+      this.pendingSystemMessage =
+        `[System: Permission mode changed to ${perm.summary}. ` +
+        `You can now: ${perm.can}. ` +
+        `You cannot: ${perm.cannot}.]`;
+    }
   }
 
   auditMemoryFile(): void {

--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -9,7 +9,7 @@ import { neutralizeTriggers } from './constants';
 import { scanPinnedFiles, scanFileInstructions } from './FrontmatterGuard';
 import type { PermissionMode } from './ClaudeProcess';
 
-const PERMISSION_DESCRIPTIONS: Record<PermissionMode, { summary: string; can: string; cannot: string }> = {
+export const PERMISSION_DESCRIPTIONS: Record<PermissionMode, { summary: string; can: string; cannot: string }> = {
   restricted: {
     summary: 'Chat only',
     can: 'respond to messages, fetch web URLs (WebFetch), search the web (WebSearch), and work with any context the user explicitly attaches',


### PR DESCRIPTION
## Summary

When the user changes the permission mode in settings mid-session, Claude wasn't told — it would continue operating under the old mode's assumptions until the session was restarted.

This queues a pending system message on settings change that gets prepended to the user's next turn, so Claude immediately knows the new mode and its capabilities. No session restart needed — "try again" is enough.

The message uses the same capability descriptions already injected at session start, e.g.:

> [System: Permission mode changed to Standard. You can now: read and write vault files and fetch the web. You cannot: run shell commands (Bash).]

Only fires if there is an active session (`currentSessionId` is set) — no spurious messages on fresh sessions.

## Test plan

- [ ] Start a session in **Chat only** mode and confirm Claude knows it can't access files
- [ ] Open settings and change mode to **Standard**
- [ ] Send any message (e.g. "try again" or "what can you do now?")
- [ ] Claude should acknowledge the new mode without needing a session restart
- [ ] Repeat switching between modes — each change should be reflected on the next send