### PR TITLE
refactor: extract AtMentionController from ClaudeView

### DIFF
--- a/docs/guide/chat-panel.md
+++ b/docs/guide/chat-panel.md
@@ -14,7 +14,7 @@ Attached items appear in a bar above the input field. Click **×** to remove an 
 
 Type `@` anywhere in the input to open an autocomplete dropdown. The currently open note is pre-selected — press **Enter** immediately to attach it. Start typing to filter by name. Press **↑ / ↓** to navigate, **Enter** or **Tab** to select, **Escape** to dismiss. The full contents of the selected note are prepended to your message.
 
-Non-Markdown files (`.fountain`, `.txt`, etc.) show their extension in the dropdown. The file types included are configurable — see **@-mention file types** in [Settings](./settings).
+Non-Markdown files show their extension in the dropdown. By default all vault files are included. To restrict to specific types, change **@-mention file types** in [Settings](./settings.md).
 
 ### Attachment button (paperclip)
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -20,7 +20,7 @@ Open **Settings → ObsidiBot** to configure:
 | **Enable debug log**               | On                                                   | Write a debug log file. See [Troubleshooting](./troubleshooting#logging).                                                                                            |
 | **Log file path**                  | `.obsidian/plugins/obsidibot/obsidibot-debug.log`    | Vault-relative path for the log file. Defaults to the plugin folder so it stays out of your vault and git history.                                                   |
 | **Log verbosity**                  | Normal                                               | **Normal** logs session events and errors. **Verbose** adds raw stream data and token breakdowns.                                                                    |
-| **@-mention file types**           | `md, pdf, fountain, txt`                             | Comma-separated file extensions included in the `@` autocomplete dropdown.                                                                                           |
+| **@-mention file types**           | `*` (all vault files)                                | Comma-separated extensions for the `@` autocomplete dropdown. `*` includes all vault files. To restrict, list extensions explicitly (e.g. `md, pdf, txt`). Add a trailing comma to also match files with no extension (e.g. `md, txt,`). |
 | **Inject split-pane files**        | On                                                   | When in split-pane view, include all visible file paths as active note context.                                                                                      |
 
 ## Session storage location

--- a/src/AtMentionController.ts
+++ b/src/AtMentionController.ts
@@ -1,0 +1,144 @@
+import { TFile, Vault } from 'obsidian';
+import { canvasToText } from './utils/canvasParser';
+
+export interface AtMentionControllerHost {
+  getAtMentionExtensions(): string;
+  getCanvasMaxChars(): number;
+  getVault(): Vault;
+  getActiveFile(): TFile | null;
+  getInputEl(): HTMLTextAreaElement;
+  injectSelectionContext(text: string, source: string): void;
+}
+
+/**
+ * Manages the @-mention autocomplete dropdown.
+ * Build the DOM element via build(), then wire input/blur/keydown events
+ * to the corresponding handle* methods.
+ */
+export class AtMentionController {
+  private dropdownEl: HTMLElement | null = null;
+  private items: TFile[] = [];
+  private index = -1;
+
+  constructor(private readonly host: AtMentionControllerHost) {}
+
+  /** Attach to the dropdown element created in onOpen(). */
+  build(dropdownEl: HTMLElement): void {
+    this.dropdownEl = dropdownEl;
+  }
+
+  /** True when the dropdown is visible. */
+  isOpen(): boolean {
+    return !!this.dropdownEl && this.dropdownEl.style.display !== 'none';
+  }
+
+  /** Call from textarea 'input' event. */
+  handleInput(): void {
+    const inputEl = this.host.getInputEl();
+    const { value, selectionStart } = inputEl;
+    if (selectionStart === null) { this.hide(); return; }
+
+    const before = value.substring(0, selectionStart);
+    const match = before.match(/@(\S*)$/);
+    if (!match) { this.hide(); return; }
+
+    const parsedExts = this.host.getAtMentionExtensions().split(',').map(e => e.trim().toLowerCase());
+    const allTypes = parsedExts.includes('*');
+    const textExts = new Set(parsedExts);
+    const query = match[1].toLowerCase();
+    const activeFile = this.host.getActiveFile();
+    const files = this.host.getVault().getFiles()
+      .filter(f => (allTypes || textExts.has(f.extension)) && (!query || f.basename.toLowerCase().includes(query)))
+      .sort((a, b) => {
+        if (!query) {
+          if (a === activeFile) return -1;
+          if (b === activeFile) return 1;
+        }
+        return a.basename.localeCompare(b.basename);
+      })
+      .slice(0, 8);
+
+    if (files.length === 0) { this.hide(); return; }
+
+    this.items = files;
+    if (this.index < 0 || this.index >= files.length) this.index = 0;
+    this.render();
+  }
+
+  /** Call from textarea 'blur' event. */
+  handleBlur(): void {
+    // Delay so mousedown on a dropdown item fires before the dropdown hides.
+    setTimeout(() => this.hide(), 150);
+  }
+
+  /**
+   * Call from textarea 'keydown' event.
+   * Returns true if the key was consumed (caller should return early).
+   */
+  handleKeyDown(e: KeyboardEvent): boolean {
+    if (!this.isOpen()) return false;
+    if (e.key === 'ArrowDown') { e.preventDefault(); this.nav(1); return true; }
+    if (e.key === 'ArrowUp') { e.preventDefault(); this.nav(-1); return true; }
+    if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); void this.select(); return true; }
+    if (e.key === 'Escape') { this.hide(); return true; }
+    return false;
+  }
+
+  hide(): void {
+    this.dropdownEl?.hide();
+    this.items = [];
+    this.index = -1;
+  }
+
+  private render(): void {
+    const el = this.dropdownEl;
+    if (!el) return;
+    el.empty();
+    el.show();
+    this.items.forEach((file, i) => {
+      const item = el.createDiv({
+        cls: 'obsidibot-at-item' + (i === this.index ? ' obsidibot-at-item-active' : ''),
+      });
+      const nameEl = item.createSpan({ cls: 'obsidibot-at-item-name', text: file.basename });
+      if (file.extension !== 'md') {
+        nameEl.createSpan({ cls: 'obsidibot-at-item-ext', text: '.' + file.extension });
+      }
+      const parentPath = file.parent?.path;
+      if (parentPath && parentPath !== '/') {
+        item.createSpan({ cls: 'obsidibot-at-item-path', text: parentPath });
+      }
+      item.addEventListener('mousedown', (e) => {
+        e.preventDefault(); // prevent textarea blur before select fires
+        this.index = i;
+        void this.select();
+      });
+    });
+  }
+
+  private nav(dir: number): void {
+    this.index = Math.max(0, Math.min(this.items.length - 1, this.index + dir));
+    this.render();
+  }
+
+  private async select(): Promise<void> {
+    const file = this.items[this.index];
+    if (!file) return;
+    this.hide();
+
+    const inputEl = this.host.getInputEl();
+    const { value, selectionStart } = inputEl;
+    if (selectionStart !== null) {
+      const before = value.substring(0, selectionStart);
+      const after = value.substring(selectionStart);
+      const newBefore = before.replace(/@\S*$/, '');
+      inputEl.value = newBefore + after;
+      inputEl.setSelectionRange(newBefore.length, newBefore.length);
+    }
+
+    const raw = await this.host.getVault().read(file);
+    const content = file.extension === 'canvas'
+      ? canvasToText(file.name, raw, this.host.getCanvasMaxChars())
+      : raw;
+    this.host.injectSelectionContext(content, file.basename);
+  }
+}

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -10,7 +10,7 @@ interface AppInternal {
 }
 import { SlashMenu, SlashCommand } from './SlashMenu';
 import { SlashParamModal, SlashParam } from './modals/SlashParamModal';
-import { canvasToText } from './utils/canvasParser';
+import { AtMentionController } from './AtMentionController';
 import { spawn } from 'child_process';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join, isAbsolute } from 'path';
@@ -112,12 +112,10 @@ export class ClaudeView extends ItemView {
   private sessionPermissionOverride: PermissionMode | null = null;
   /** Pending system message to prepend to the next continuing-session turn (allowlist update, context refresh, etc.). */
   private pendingSystemMessage: string | null = null;
-  private atDropdownEl: HTMLElement;
-  private atDropdownItems: TFile[] = [];
+  private atMentionController: AtMentionController;
   private tokenGauge: TokenGauge;
   private attachPopoverEl: HTMLElement;
   private permissionIconEl!: HTMLButtonElement;
-  private atDropdownIndex = -1;
   private currentUserLabel = 'User';
   private currentAssistantLabel = 'ObsidiBot';
 
@@ -136,6 +134,14 @@ export class ClaudeView extends ItemView {
       getConfigDir: () => this.app.vault.configDir,
       getCanvasMaxChars: () => this.plugin.settings.canvasMaxChars,
       focusInput: () => this.inputEl?.focus(),
+    });
+    this.atMentionController = new AtMentionController({
+      getAtMentionExtensions: () => this.plugin.settings.atMentionExtensions,
+      getCanvasMaxChars: () => this.plugin.settings.canvasMaxChars,
+      getVault: () => this.app.vault,
+      getActiveFile: () => this.app.workspace.getActiveFile(),
+      getInputEl: () => this.inputEl,
+      injectSelectionContext: (text, source) => this.injectSelectionContext(text, source),
     });
   }
 
@@ -194,8 +200,9 @@ export class ClaudeView extends ItemView {
     const inputArea = root.createDiv({ cls: 'obsidibot-input-area' });
     this.inputAreaEl = inputArea;
 
-    this.atDropdownEl = inputArea.createDiv({ cls: 'obsidibot-at-dropdown' });
-    this.atDropdownEl.hide();
+    const atDropdownEl = inputArea.createDiv({ cls: 'obsidibot-at-dropdown' });
+    atDropdownEl.hide();
+    this.atMentionController.build(atDropdownEl);
 
     this.attachPopoverEl = inputArea.createDiv({ cls: 'obsidibot-attach-popover' });
     this.attachPopoverEl.hide();
@@ -255,13 +262,12 @@ export class ClaudeView extends ItemView {
       }
     });
     this.inputEl.addEventListener('input', () => {
-      this.handleAtMention();
+      this.atMentionController.handleInput();
       this.handleSlashTrigger();
     });
 
     this.inputEl.addEventListener('blur', () => {
-      // Delay so mousedown on a dropdown item fires before the dropdown hides
-      setTimeout(() => this.atDropdownHide(), 150);
+      this.atMentionController.handleBlur();
     });
 
     this.inputEl.addEventListener('keydown', (e) => {
@@ -273,12 +279,7 @@ export class ClaudeView extends ItemView {
       }
 
       // Dropdown navigation takes priority over everything else
-      if (this.atDropdownEl.style.display !== 'none') {
-        if (e.key === 'ArrowDown') { e.preventDefault(); this.atDropdownNav(1); return; }
-        if (e.key === 'ArrowUp') { e.preventDefault(); this.atDropdownNav(-1); return; }
-        if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); void this.atDropdownSelect(); return; }
-        if (e.key === 'Escape') { this.atDropdownHide(); return; }
-      }
+      if (this.atMentionController.handleKeyDown(e)) return;
 
       if (e.key === 'Enter' && !e.shiftKey && this.plugin.settings.sendOnEnter) {
         e.preventDefault();
@@ -1458,91 +1459,6 @@ export class ClaudeView extends ItemView {
         setTimeout(() => copyBtn.setText('Copy'), 2000);
       });
     });
-  }
-
-  private handleAtMention() {
-    const { value, selectionStart } = this.inputEl;
-    if (selectionStart === null) { this.atDropdownHide(); return; }
-
-    const before = value.substring(0, selectionStart);
-    const match = before.match(/@(\S*)$/);
-    if (!match) { this.atDropdownHide(); return; }
-
-    const textExts = new Set(
-      this.plugin.settings.atMentionExtensions.split(',').map(e => e.trim().toLowerCase()).filter(Boolean)
-    );
-    const query = match[1].toLowerCase();
-    const activeFile = this.app.workspace.getActiveFile();
-    const files = this.app.vault.getFiles()
-      .filter(f => textExts.has(f.extension) && (!query || f.basename.toLowerCase().includes(query)))
-      .sort((a, b) => {
-        // Active note always sorts first when no query is typed
-        if (!query) {
-          if (a === activeFile) return -1;
-          if (b === activeFile) return 1;
-        }
-        return a.basename.localeCompare(b.basename);
-      })
-      .slice(0, 8);
-
-    if (files.length === 0) { this.atDropdownHide(); return; }
-
-    this.atDropdownItems = files;
-    if (this.atDropdownIndex < 0 || this.atDropdownIndex >= files.length) {
-      this.atDropdownIndex = 0;
-    }
-    this.atDropdownRender();
-  }
-
-  private atDropdownRender() {
-    const el = this.atDropdownEl;
-    el.empty();
-    el.show();
-    this.atDropdownItems.forEach((file, i) => {
-      const item = el.createDiv({ cls: 'obsidibot-at-item' + (i === this.atDropdownIndex ? ' obsidibot-at-item-active' : '') });
-      const nameEl = item.createSpan({ cls: 'obsidibot-at-item-name', text: file.basename });
-      if (file.extension !== 'md') nameEl.createSpan({ cls: 'obsidibot-at-item-ext', text: '.' + file.extension });
-      const parentPath = file.parent?.path;
-      if (parentPath && parentPath !== '/') {
-        item.createSpan({ cls: 'obsidibot-at-item-path', text: parentPath });
-      }
-      item.addEventListener('mousedown', (e) => {
-        e.preventDefault(); // prevent textarea blur before select fires
-        this.atDropdownIndex = i;
-        void this.atDropdownSelect();
-      });
-    });
-  }
-
-  private atDropdownNav(dir: number) {
-    this.atDropdownIndex = Math.max(0, Math.min(this.atDropdownItems.length - 1, this.atDropdownIndex + dir));
-    this.atDropdownRender();
-  }
-
-  private async atDropdownSelect() {
-    const file = this.atDropdownItems[this.atDropdownIndex];
-    if (!file) return;
-    this.atDropdownHide();
-
-    // Remove @query from textarea and restore cursor
-    const { value, selectionStart } = this.inputEl;
-    if (selectionStart !== null) {
-      const before = value.substring(0, selectionStart);
-      const after = value.substring(selectionStart);
-      const newBefore = before.replace(/@\S*$/, '');
-      this.inputEl.value = newBefore + after;
-      this.inputEl.setSelectionRange(newBefore.length, newBefore.length);
-    }
-
-    const raw = await this.app.vault.read(file);
-    const content = file.extension === 'canvas' ? canvasToText(file.name, raw, this.plugin.settings.canvasMaxChars) : raw;
-    this.injectSelectionContext(content, file.basename);
-  }
-
-  private atDropdownHide() {
-    this.atDropdownEl.hide();
-    this.atDropdownItems = [];
-    this.atDropdownIndex = -1;
   }
 
   private scrollToBottom() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -82,7 +82,7 @@ export const DEFAULT_SETTINGS: ObsidiBotSettings = {
   logEnabled: false,
   logFilePath: '',
   logVerbosity: 'normal',
-  atMentionExtensions: 'md, canvas, pdf, fountain, txt',
+  atMentionExtensions: '*',
   injectSplitPaneFiles: true,
   injectStackedTabFiles: false,
   exportFolder: 'ObsidiBot Exports',
@@ -147,7 +147,7 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('@-mention file types')
       // eslint-disable-next-line obsidianmd/ui/sentence-case
-      .setDesc('Comma-separated extensions to include in @-mention search (e.g. md, pdf, fountain, txt).')
+      .setDesc('Comma-separated extensions for @-mention search (e.g. md, pdf, txt). Use * to match all file types. Add a trailing comma to also include files with no extension.')
       .addText((text) =>
         text
           // eslint-disable-next-line obsidianmd/ui/sentence-case


### PR DESCRIPTION
## What

Extracts `AtMentionController` into `src/AtMentionController.ts` — third step in the ClaudeView God-class refactor (TokenGauge #203, AttachmentHandler #204).

**Moves out of ClaudeView:**
- `atDropdownEl`, `atDropdownItems`, `atDropdownIndex` fields
- `handleAtMention()`, `atDropdownRender()`, `atDropdownNav()`, `atDropdownSelect()`, `atDropdownHide()`
- `canvasToText` import (only used by atDropdownSelect)

**ClaudeView retains:**
- A local `atDropdownEl` created in `onOpen()` and passed to `atMentionController.build()`
- `atMentionController: AtMentionController` field wired via `AtMentionControllerHost` interface
- Keydown handler simplified to `if (this.atMentionController.handleKeyDown(e)) return;`

**Also fixes @-mention file filtering (pre-existing bugs, safe to fix here):**
- Default changed from `md, canvas, pdf, fountain, txt` to `*` (all vault files)
- `filter(Boolean)` removed from extension parsing — extensionless files (`LICENSE` etc.) now matchable via trailing comma in the setting
- `*` wildcard short-circuits the extension check entirely
- Settings UI description and user docs updated

No other behaviour changes. Build is clean.

## What to test

- Type `@` in the input — dropdown appears with up to 8 files, active note pre-selected
- Type to filter by name; Arrow up/down to navigate; Enter or Tab to select; Escape to dismiss
- Click an item with the mouse (mousedown select, no textarea blur race)
- Selecting a note removes the `@query` from the textarea and adds the note as a context badge
- The `@ add note` button in the attach popover inserts `@` at cursor and opens the dropdown
- Default setting `*`: all vault files (md, canvas, log, LICENSE, etc.) appear

**Extension filter testing:**
- Change "@-mention file types" to `md, txt` — only those extensions appear
- Change to `md, txt,` (trailing comma) — extensionless files also appear
- Change back to `*` — everything appears again

**Regression:**
- Paste, drag-drop, file picker, URL attach still work
- Send on Enter still works
- Arrow-up input history still works (keydown handler unchanged outside dropdown block)

## What to watch out for

- Dropdown not appearing → `build()` not called or `dropdownEl` reference null
- Blur/select race condition → mousedown on an item should still select before blur hides the dropdown (150ms delay preserved in `handleBlur()`)
- `*` showing unexpected system files → shouldn't happen; `vault.getFiles()` excludes `.obsidian/`, `.git/` etc. as Obsidian doesn't index them