### PR TITLE
refactor: centralize AppInternal interface into src/obsidianInternal.ts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -9,15 +9,7 @@ import { initLogger, log, warn } from './src/utils/logger';
 import { AboutModal } from './src/modals/AboutModal';
 import { MemoryAuditModal } from './src/modals/MemoryAuditModal';
 import { ContextGenerationModal } from './src/ContextGenerationModal';
-
-/** Minimal shape of Obsidian's private settings/commands APIs. */
-interface AppInternal {
-  setting: { open(): void; openTabById(id: string): void };
-  commands: {
-    commands: Record<string, { id: string; name: string }>;
-    removeCommand(id: string): void;
-  };
-}
+import { AppInternal } from './src/obsidianInternal';
 
 export default class ObsidiBotPlugin extends Plugin {
   settings: ObsidiBotSettings;

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -3,11 +3,7 @@ import spriteUrl from '../assets/media/ObsidiBotSprite_800x800.png';
 import logoUrl from '../assets/media/logo.png';
 import welcomeData from './welcome.json';
 
-/** Minimal shape of Obsidian's private settings/commands APIs. */
-interface AppInternal {
-  setting: { open(): void; openTabById(id: string): void };
-  commands: { commands: Record<string, { id: string; name: string }> };
-}
+import { AppInternal } from './obsidianInternal';
 import { SlashMenu, SlashCommand } from './SlashMenu';
 import { SlashParamModal, SlashParam } from './modals/SlashParamModal';
 import { AtMentionController } from './AtMentionController';

--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -1,8 +1,5 @@
 import { App } from 'obsidian';
-
-interface AppInternal {
-  commands: { commands: Record<string, { id: string; name: string }> };
-}
+import { AppInternal } from './obsidianInternal';
 import { buildVaultTree } from './utils/fileTree';
 import { log, estimateTokens } from './utils/logger';
 import { neutralizeTriggers } from './constants';

--- a/src/SessionCoordinator.ts
+++ b/src/SessionCoordinator.ts
@@ -109,7 +109,7 @@ export class SessionCoordinator {
     event: K,
     listener: (...args: SessionCoordinatorEvents[K]) => void,
   ): this {
-    this._emitter.on(event as string, listener as (...args: unknown[]) => void);
+    this._emitter.on(event, listener);
     return this;
   }
 
@@ -117,7 +117,7 @@ export class SessionCoordinator {
     event: K,
     listener: (...args: SessionCoordinatorEvents[K]) => void,
   ): this {
-    this._emitter.off(event as string, listener as (...args: unknown[]) => void);
+    this._emitter.off(event, listener);
     return this;
   }
 
@@ -125,7 +125,7 @@ export class SessionCoordinator {
     event: K,
     ...args: SessionCoordinatorEvents[K]
   ): void {
-    this._emitter.emit(event as string, ...args);
+    this._emitter.emit(event, ...args);
   }
 
   // ── State accessors ────────────────────────────────────────────────────────

--- a/src/obsidianInternal.ts
+++ b/src/obsidianInternal.ts
@@ -1,0 +1,11 @@
+/**
+ * Minimal shape of Obsidian's private App APIs used across ObsidiBot.
+ * Cast via: `(this.app as unknown as AppInternal)`
+ */
+export interface AppInternal {
+  setting: { open(): void; openTabById(id: string): void };
+  commands: {
+    commands: Record<string, { id: string; name: string }>;
+    removeCommand(id: string): void;
+  };
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,10 +2,7 @@ import { App, PluginSettingTab, Setting } from 'obsidian';
 import type ObsidiBotPlugin from '../main';
 import type { PermissionMode } from './ClaudeProcess';
 export type { PermissionMode };
-
-interface AppInternal {
-  commands: { commands: Record<string, { id: string; name: string }> };
-}
+import { AppInternal } from './obsidianInternal';
 
 export interface ObsidiBotSettings {
   binaryPath: string;


### PR DESCRIPTION
## Summary

- Four files (`main.ts`, `ClaudeView.ts`, `ContextManager.ts`, `settings.ts`) each had a local `AppInternal` interface definition that had drifted apart over time
- Consolidated into a single superset interface in the new `src/obsidianInternal.ts` module; all four files now import from there
- Fixed five unnecessary type assertions (`event as string`, `listener as (...args: unknown[]) => void`) in `SessionCoordinator.ts` introduced by the prior refactor — these caused ESLint violations under the project ruleset

## Test plan

- [ ] `npm run build` passes with no errors
- [ ] `npx eslint src/ main.ts` passes with no violations
- [ ] Session start, send a message, verify no console errors related to settings or commands