### PR TITLE
fix: surface stdin null as explicit error; document protocol freeze and design decisions

### DIFF
--- a/src/ClaudeProcess.ts
+++ b/src/ClaudeProcess.ts
@@ -144,8 +144,13 @@ export function spawnClaude(opts: SpawnOptions): ChildProcess {
 
   // Write prompt via stdin — bypasses all shell/arg quoting issues.
   // claude --print reads from stdin when no positional prompt arg is given.
-  proc.stdin?.write(opts.prompt, 'utf8');
-  proc.stdin?.end();
+  if (!proc.stdin) {
+    // stdin null means the process failed to open the pipe; throw so the
+    // try/catch in the caller surfaces a real error instead of a silent close.
+    throw new Error('Claude process started with no stdin pipe — cannot send prompt.');
+  }
+  proc.stdin.write(opts.prompt, 'utf8');
+  proc.stdin.end();
 
   return proc;
 }

--- a/src/SessionCoordinator.ts
+++ b/src/SessionCoordinator.ts
@@ -339,7 +339,10 @@ export class SessionCoordinator {
       this.emit('session:updated', { title: this._sessionTitle, sessionId });
       log('Placeholder session updated:', placeholderId, '→', sessionId);
     } else if (wasNew && firstUserInput) {
-      // Brand-new session with no pre-created placeholder
+      // Brand-new session with no pre-created placeholder.
+      // In practice this branch is unreachable through the normal UI: startNewSession()
+      // always sets _placeholderSessionId, and loadSession() sets it for new sessions.
+      // This is a defensive guard in case send() is called on an unconfigured coordinator.
       this._sessionId = sessionId;
       this._sessionFileId = sessionId;
       this._sessionTitle = titleFromPrompt(firstUserInput);

--- a/src/TokenGauge.ts
+++ b/src/TokenGauge.ts
@@ -114,6 +114,12 @@ export class TokenGauge {
     this.confirmEl.classList.remove('is-visible');
   }
 
+  /**
+   * Trigger Claude Code's native /compact slash command via a --resume turn.
+   * Claude Code writes a compact_boundary entry to the session .jsonl; ObsidiBot
+   * reads that marker in loadSessionMessages() to render the compaction divider.
+   * No custom summarization is performed here — all compaction logic lives in the CLI.
+   */
   compact(): void {
     const sessionId = this.host.getSessionId();
     if (!sessionId) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,19 @@
-/** Prefix Claude emits to signal a ObsidiBot UI action. Must match ContextManager injection. */
+/**
+ * Prefix Claude emits to signal an ObsidiBot UI action. Must match ContextManager injection.
+ *
+ * FROZEN: The "CORTEX" name predates the ObsidiBot rename and is intentionally kept as the
+ * wire format. Renaming would break all existing _claude-context.md files, session .jsonl
+ * histories, and any skill files that reference the protocol. A future hardening option is to
+ * rotate or obfuscate this prefix periodically to reduce prompt-injection surface — but the
+ * current risk is low because neutralizeTriggers() strips the prefix from all vault-sourced
+ * content before it reaches the model.
+ */
 export const ACTION_PREFIX = '@@CORTEX_ACTION ';
 
-/** Prefix Claude emits to query live vault state. Must match ContextManager injection. */
+/**
+ * Prefix Claude emits to query live vault state. Must match ContextManager injection.
+ * See ACTION_PREFIX for freeze rationale.
+ */
 export const QUERY_PREFIX = '@@CORTEX_QUERY ';
 
 /**


### PR DESCRIPTION
## Summary

Closes out the actionable items from the code review open questions.

- **Q9 — stdin null silent failure**: `spawnClaude` now throws when `proc.stdin` is null instead of silently doing nothing. The existing `try/catch` in `SessionCoordinator.send()` converts this to `turn:error`, so the UI shows a real failure message instead of a misleading "Interrupted."
- **Q1 — CORTEX_ prefix freeze**: Added a doc comment to `constants.ts` explaining why the wire-protocol prefix is intentionally kept as "CORTEX" despite the product rename, and noting the future obfuscation/rotation option for hardening against prompt injection.
- **Q5 — dead branch 2 in _persistSessionAfterTurn**: Added a comment explaining that branch 2 (`wasNew + no placeholder`) is unreachable through normal UI flows; it's a defensive guard only.
- **Q6 — compactSession mechanism**: Added a doc comment to `TokenGauge.compact()` clarifying it delegates to Claude Code's native `/compact` slash command — no custom summarization in ObsidiBot.

Issues filed:
- **Q4** (handleVaultInject recursion) → #214

Items closed by discussion, no code change needed:
- Q2 (suppressNextUserBubble): understood, no action
- Q8 (pendingSystemMessage discard): accepted as correct behavior
- Q10 (session storage in git): low-risk, no action

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes