### PR TITLE
feat: rename note param type to obsidianmd_note for Claude Code compatibility

### DIFF
--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -61,7 +61,7 @@ When `params` is defined, ObsidiBot shows a modal form before running the skill.
 | `textarea`   | Multi-line text field                                                                                                         |
 | `dropdown`   | Select from a fixed list of options                                                                                           |
 | `checkboxes` | One or more boolean toggles — result is a comma-separated string                                                              |
-| `note`       | Vault note picker — fuzzy search over all vault notes; injects the **full note content** as an attachment (same as @-mention) |
+| `obsidianmd_note` | Vault note picker — fuzzy search over all vault notes; injects the **full note content** as an attachment (same as @-mention). Alias: `note` (legacy, still supported) |
 
 ### Variable interpolation
 
@@ -170,7 +170,7 @@ description: Summarize any vault note
 autorun: true
 params:
   - id: target_note
-    type: note
+    type: obsidianmd_note
     label: Note to summarize
     validations:
       required: true
@@ -195,7 +195,7 @@ params:
     validations:
       required: true
   - id: context_note
-    type: note
+    type: obsidianmd_note
     label: Relevant design note (optional)
 ---
 You are acting as a senior software engineer working in this vault's codebase.

--- a/src/modals/SlashParamModal.ts
+++ b/src/modals/SlashParamModal.ts
@@ -2,13 +2,19 @@ import { App, FuzzySuggestModal, Modal, TFile } from 'obsidian';
 
 export interface SlashParam {
   id: string;
-  type: 'input' | 'textarea' | 'dropdown' | 'checkboxes' | 'note';
+  /** `obsidianmd_note` is the canonical vault-picker type; `note` is a legacy alias. */
+  type: 'input' | 'textarea' | 'dropdown' | 'checkboxes' | 'obsidianmd_note' | 'note';
   label: string;
   description?: string;
   placeholder?: string;
   options?: string[];
   default?: string;
   validations?: { required?: boolean };
+}
+
+/** True for both the canonical `obsidianmd_note` type and the legacy `note` alias. */
+function isNoteType(type: SlashParam['type']): boolean {
+  return type === 'obsidianmd_note' || type === 'note';
 }
 
 export interface SlashParamAttachment {
@@ -41,7 +47,7 @@ export class SlashParamModal extends Modal {
   ) {
     super(app);
     for (const p of params) {
-      if (p.type !== 'note') this.values[p.id] = p.default ?? '';
+      if (!isNoteType(p.type)) this.values[p.id] = p.default ?? '';
     }
   }
 
@@ -101,7 +107,7 @@ export class SlashParamModal extends Modal {
           });
         }
 
-      } else if (param.type === 'note') {
+      } else if (isNoteType(param.type)) {
         const noteInput = fieldEl.createEl('input', {
           cls: 'obsidibot-param-input obsidibot-param-note-input',
           attr: { type: 'text', placeholder: 'Click to pick a note…', readonly: 'true' },
@@ -133,7 +139,7 @@ export class SlashParamModal extends Modal {
       let valid = true;
       for (const param of this.params) {
         const errEl = errorEls[param.id];
-        const hasValue = param.type === 'note'
+        const hasValue = isNoteType(param.type)
           ? !!this.noteValues[param.id]
           : !!this.values[param.id]?.trim();
         if (param.validations?.required && !hasValue) {
@@ -151,7 +157,7 @@ export class SlashParamModal extends Modal {
       const attachments: SlashParamAttachment[] = [];
 
       for (const param of this.params) {
-        if (param.type === 'note') {
+        if (isNoteType(param.type)) {
           const note = this.noteValues[param.id];
           if (note) attachments.push({ text: note.content, source: note.basename });
           // Remove the {{id}} placeholder from the prompt body
@@ -175,7 +181,7 @@ export class SlashParamModal extends Modal {
   }
 }
 
-/** Fuzzy vault-file picker used by the `note` field type. */
+/** Fuzzy vault-file picker used by the `obsidianmd_note` field type (and legacy `note` alias). */
 class NotePicker extends FuzzySuggestModal<TFile> {
   constructor(app: App, private onChoose: (file: TFile) => Promise<void>) {
     super(app);


### PR DESCRIPTION
## Summary

- Renames the `note` skill param type to `obsidianmd_note` as the canonical name
- When a skill runs outside ObsidiBot (e.g. in Claude Code CLI), Claude sees the frontmatter and can infer from the type name that it should ask for a markdown note path and read the file itself via its Read tool — graceful degradation rather than a silent blank
- `note` remains a fully supported alias; all existing skills work without changes
- Adds `isNoteType()` helper so all note-type checks are in one place
- Updates docs examples and the field type table to show `obsidianmd_note` as canonical

## Compatibility

| Context | Behavior |
|---|---|
| ObsidiBot (new) | `obsidianmd_note` → vault picker, note injected as attachment |
| ObsidiBot (legacy) | `note` → identical vault picker behavior (alias) |
| Claude Code CLI | Claude reads `type: obsidianmd_note` in frontmatter, asks for a note path, reads via Read tool |

## Test plan

- [ ] Skill with `type: note` still shows vault picker (alias works)
- [ ] Skill with `type: obsidianmd_note` shows vault picker (canonical works)
- [ ] `npm run build` passes