### PR TITLE
feat: Claude Code skill format compatibility

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -438,10 +438,18 @@ export default class ObsidiBotPlugin extends Plugin {
     if (!existsSync(folder)) return;
 
     try {
-      const files = readdirSync(folder).filter(f => f.endsWith('.md'));
-      for (const file of files) {
-        const filePath = join(folder, file);
-        const name = file.replace(/\.md$/, '');
+      const skillEntries: { filePath: string; name: string }[] = [];
+      for (const entry of readdirSync(folder, { withFileTypes: true })) {
+        if (entry.isFile() && entry.name.endsWith('.md')) {
+          skillEntries.push({ filePath: join(folder, entry.name), name: entry.name.replace(/\.md$/, '') });
+        } else if (entry.isDirectory()) {
+          const skillMd = join(folder, entry.name, 'SKILL.md');
+          if (existsSync(skillMd)) {
+            skillEntries.push({ filePath: skillMd, name: entry.name });
+          }
+        }
+      }
+      for (const { filePath, name } of skillEntries) {
         const commandId = `skill-${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
         const fullId = `obsidibot:${commandId}`;
 
@@ -464,7 +472,7 @@ export default class ObsidiBotPlugin extends Plugin {
 
         this.skillCommandIds.add(fullId);
       }
-      log(`Registered ${files.length} skill(s) in Ctrl+P`);
+      log(`Registered ${skillEntries.length} skill(s) in Ctrl+P`);
     } catch (e) {
       warn('Failed to register skill commands:', e);
     }

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1720,7 +1720,11 @@ export class ClaudeView extends ItemView {
       let body = raw;
       let params: SlashParam[] | undefined;
       let autorun = false;
-      const name = filePath.split(/[\\/]/).pop()?.replace(/\.md$/, '') ?? 'Command';
+      const pathParts = filePath.split(/[\\/]/);
+      const fileName = pathParts[pathParts.length - 1] ?? '';
+      const name = fileName === 'SKILL.md'
+        ? (pathParts[pathParts.length - 2] ?? 'Command')
+        : fileName.replace(/\.md$/, '') || 'Command';
 
       const fmMatch = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
       if (fmMatch) {
@@ -1728,7 +1732,17 @@ export class ClaudeView extends ItemView {
         try {
           const fm = parseYaml(fmMatch[1]) as Record<string, unknown>;
           if (fm.autorun === true) autorun = true;
-          if (Array.isArray(fm.params)) params = fm.params as SlashParam[];
+          if (Array.isArray(fm.params)) {
+            params = fm.params as SlashParam[];
+          } else if (Array.isArray(fm.arguments)) {
+            const argHint = typeof fm['argument-hint'] === 'string' ? fm['argument-hint'] : '';
+            params = (fm.arguments as string[]).map((argName, i) => ({
+              id: String(argName),
+              type: 'input' as const,
+              label: String(argName),
+              placeholder: i === 0 ? argHint : '',
+            }));
+          }
         } catch { /* use defaults */ }
       }
 
@@ -1772,10 +1786,20 @@ export class ClaudeView extends ItemView {
     if (!existsSync(folder)) return [];
     const commands: SlashCommand[] = [];
     try {
-      const files = readdirSync(folder).filter(f => f.endsWith('.md'));
-      for (const file of files) {
+      const skillEntries: { filePath: string; name: string }[] = [];
+      for (const entry of readdirSync(folder, { withFileTypes: true })) {
+        if (entry.isFile() && entry.name.endsWith('.md')) {
+          skillEntries.push({ filePath: join(folder, entry.name), name: entry.name.replace(/\.md$/, '') });
+        } else if (entry.isDirectory()) {
+          const skillMd = join(folder, entry.name, 'SKILL.md');
+          if (existsSync(skillMd)) {
+            skillEntries.push({ filePath: skillMd, name: entry.name });
+          }
+        }
+      }
+      for (const { filePath, name } of skillEntries) {
         try {
-          const raw = readFileSync(join(folder, file), 'utf8');
+          const raw = readFileSync(filePath, 'utf8');
           let body = raw;
           let category = 'Prompts';
           let description: string | undefined;
@@ -1790,11 +1814,19 @@ export class ClaudeView extends ItemView {
               if (typeof fm.category === 'string') category = fm.category;
               if (typeof fm.description === 'string') description = fm.description;
               if (fm.autorun === true) autorun = true;
-              if (Array.isArray(fm.params)) params = fm.params as SlashParam[];
+              if (Array.isArray(fm.params)) {
+                params = fm.params as SlashParam[];
+              } else if (Array.isArray(fm.arguments)) {
+                const argHint = typeof fm['argument-hint'] === 'string' ? fm['argument-hint'] : '';
+                params = (fm.arguments as string[]).map((argName, i) => ({
+                  id: String(argName),
+                  type: 'input' as const,
+                  label: String(argName),
+                  placeholder: i === 0 ? argHint : '',
+                }));
+              }
             } catch { /* malformed frontmatter — use defaults */ }
           }
-
-          const name = file.replace(/\.md$/, '');
           commands.push({
             category,
             name,

--- a/src/modals/SlashParamModal.ts
+++ b/src/modals/SlashParamModal.ts
@@ -168,6 +168,19 @@ export class SlashParamModal extends Modal {
         }
       }
 
+      // $ARGUMENTS / $name / $0 interpolation (Claude Code skills format)
+      const positional = this.params.filter(p => p.id in this.values);
+      const allArgValues = positional.map(p => (this.values[p.id] ?? '').trim()).filter(v => v);
+      result = result.replace(/\$ARGUMENTS\b/g, allArgValues.join(' '));
+      positional.forEach((p, i) => {
+        result = result.replace(new RegExp(`\\$${i}(?!\\d)`, 'g'), this.values[p.id] ?? '');
+      });
+      const sortedByLength = [...positional].sort((a, b) => b.id.length - a.id.length);
+      for (const p of sortedByLength) {
+        const escapedId = p.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        result = result.replace(new RegExp(`\\$${escapedId}(?![\\w])`, 'g'), this.values[p.id] ?? '');
+      }
+
       // Strip any remaining unresolved tokens and collapse extra blank lines
       result = result.replace(/\{\{\w+\}\}/g, '').replace(/\n{3,}/g, '\n\n').trim();
 


### PR DESCRIPTION
## Summary

- Skill loader (both slash menu and Ctrl+P) now detects `<name>/SKILL.md` subdirectories alongside flat `.md` files — Claude Code skills work without conversion
- `arguments:` / `argument-hint:` frontmatter auto-generates `input` params when `params:` is absent; `params:` wins when both are present
- `$ARGUMENTS`, `$0`/`$1`, and `$name` tokens are interpolated in `SlashParamModal` alongside the existing `{{id}}` path

## Compatibility

ObsidiBot skills are a strict superset of the Claude Code skill format. A skill authored for Claude Code / Cursor / Gemini CLI will load and run in ObsidiBot as-is. ObsidiBot's typed `params` (dropdown, checkboxes, obsidianmd_note picker) remain available as an opt-in upgrade.

| Format | Loads | UI form | Interpolation |
|---|---|---|---|
| ObsidiBot (`params:`) | ✓ | Full typed form | `{{id}}` |
| Claude Code (`arguments:`) | ✓ | Auto text inputs | `$name` / `$0` / `$ARGUMENTS` |
| Both present | ✓ | `params:` wins | Both token styles |
| No frontmatter | ✓ | Direct insert/run | — |

## Test plan

- [ ] Flat `.md` skill in skills folder still loads and runs
- [ ] `<name>/SKILL.md` subdirectory appears in `/` menu with the directory name
- [ ] Skill with `arguments:` shows auto-generated text input fields
- [ ] `argument-hint:` string appears as placeholder on first field
- [ ] `$ARGUMENTS` in body replaced with space-joined values on submit
- [ ] `$name` replaced with named field value; `$0` with positional
- [ ] Skill with both `params:` and `arguments:` uses `params:` form
- [ ] Existing `{{id}}` ObsidiBot skills unaffected