### PR TITLE
fix: default registerSkillsAsCommands to true

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -86,7 +86,7 @@ export const DEFAULT_SETTINGS: ObsidiBotSettings = {
   lastActiveSessionId: '',
   sessionStoragePath: '',
   commandsFolder: '',
-  registerSkillsAsCommands: false,
+  registerSkillsAsCommands: true,
   persistFullAccess: false,
   canvasMaxChars: 50000,
 };


### PR DESCRIPTION
Closes #147

One-line default change in `DEFAULT_SETTINGS`. Skills now appear in Ctrl+P on a fresh install without requiring the user to discover and enable the setting manually.

Existing installs are unaffected — persisted settings take precedence over the default.

## Test plan
- [ ] Fresh install (no existing `data.json`): skills appear in Ctrl+P without any settings change
- [ ] Existing install with setting explicitly set to `false`: still off after upgrade
- [ ] Existing install with setting explicitly set to `true`: no change