### PR TITLE
feat: permission picker popover + Ctrl+P command

### DIFF
--- a/docs/guide/chat-panel.md
+++ b/docs/guide/chat-panel.md
@@ -43,6 +43,21 @@ Highlight text in any open note, then run **ObsidiBot: Send selection as context
 
 ---
 
+## Permission Icon
+
+A **colored icon** in the input toolbar shows the current permission mode at a glance:
+
+| Icon | Color | Mode |
+|------|-------|------|
+| lock | blue | Chat only |
+| eye | green | Read only |
+| shield | yellow | Standard |
+| triangle | red | Full access |
+
+Click it to open a quick picker and switch modes. The change takes effect on the next message. See [Permissions](./permissions.md) for details on what each mode allows.
+
+---
+
 ## Context Gauge
 
 A **ring icon** appears in the input bar after your first message. Hover to see how much of the 200K token context window remains. Click it to manually compact the session history if it's filling up.

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -24,6 +24,7 @@ Press **Ctrl+P** (Windows/Linux) or **Cmd+P** (Mac) to open the Command Palette 
 | **ObsidiBot: Export conversation**       | `export-obsidibot-conversation` | Copy the current conversation as markdown to the clipboard.                                                                     |
 | **ObsidiBot: Export session to vault**   | `export-obsidibot-to-vault`     | Save the current conversation as a vault note. Prompts for a path (defaults to configured Export folder).                       |
 | **ObsidiBot: Copy last response**        | `copy-obsidibot-last-response`  | Copy Claude's last response to the clipboard.                                                                                   |
+| **ObsidiBot: Change permission mode**    | `change-obsidibot-permission-mode` | Open a picker to switch the active permission mode (Chat only / Read only / Standard / Full access). Takes effect on the next message. |
 | **ObsidiBot: Open settings**             | `open-obsidibot-settings`       | Jump directly to the ObsidiBot settings panel.                                                                                  |
 | **ObsidiBot: Send selection as context** | `send-selection-to-obsidibot`   | Highlight text in any note, then run this command to attach it as context.                                                      |
 | **ObsidiBot: Focus chat input**          | `focus-obsidibot-input`         | Open the ObsidiBot panel and place the cursor in the chat input. Good for hotkey binding.                                       |

--- a/docs/guide/permissions.md
+++ b/docs/guide/permissions.md
@@ -11,7 +11,11 @@ ObsidiBot runs Claude Code as a subprocess and controls what it's allowed to do 
 | **Read only**                | 🟢 eye      | Read files, search, fetch web — no writes or shell commands                               |
 | **Full access**              | 🔴 warning  | Everything, including shell commands (Bash, git, etc.)                                    |
 
-Configure in **Settings → ObsidiBot → Permission mode**.
+**Change the mode any time** by clicking the colored permission icon in the input toolbar — a picker appears above it with all four options. The current mode is highlighted. Use arrow keys + Enter or click to select; Escape or click outside to cancel.
+
+The same picker is available from the Command Palette: **ObsidiBot: Change permission mode**.
+
+The default for new sessions is set in **Settings → ObsidiBot → Permission mode**.
 
 ### Chat only
 
@@ -34,7 +38,7 @@ The upgrade option in the denial card depends on the current mode:
 - **Chat only** → offers **Allow standard access for this session**
 - **Standard / Read only** → offers **Allow full access for this session**
 
-The session override is cleared when you start a new session or when you change the permission mode in settings.
+The session override is cleared when you start a new session or when you change the permission mode via the picker or settings.
 
 ::: warning
 Permission granularity is at the **tool level**, not the command level. "Allow full access" unlocks all shell commands for the rest of the session — there is no way to approve `git status` while still blocking `rm`. This is a constraint of how Claude Code works in streaming mode.

--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,7 @@ import { MemoryAuditModal } from './src/modals/MemoryAuditModal';
 import { ContextGenerationModal } from './src/ContextGenerationModal';
 import { AppInternal } from './src/obsidianInternal';
 import { resolveSkillsFolder, scanSkillFolder } from './src/SkillLoader';
+import { PermissionPickerModal } from './src/modals/PermissionPickerModal';
 
 export default class ObsidiBotPlugin extends Plugin {
   settings: ObsidiBotSettings;
@@ -216,6 +217,14 @@ export default class ObsidiBotPlugin extends Plugin {
       callback: () => {
         this.showAbout();
       }
+    });
+
+    this.addCommand({
+      id: 'change-permission-mode',
+      name: 'Change permission mode',
+      callback: () => {
+        new PermissionPickerModal(this.app, this, this.getEffectivePermissionMode()).open();
+      },
     });
 
     this.addCommand({

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -6,6 +6,7 @@ import welcomeData from './welcome.json';
 import { AppInternal } from './obsidianInternal';
 import { SlashMenu, SlashCommand } from './SlashMenu';
 import { SlashParamModal } from './modals/SlashParamModal';
+import { openPermissionPopover } from './modals/PermissionPickerModal';
 import { AtMentionController } from './AtMentionController';
 import { spawn } from 'child_process';
 import { SkillDef, resolveSkillsFolder, loadSkills, parseSkillFile, nameFromPath } from './SkillLoader';
@@ -437,8 +438,7 @@ export class ClaudeView extends ItemView {
 
     this.permissionIconEl = inputToolbar.createEl('button', { cls: 'obsidibot-icon-btn obsidibot-input-toolbar-btn obsidibot-permission-icon' });
     this.permissionIconEl.addEventListener('click', () => {
-      this.appInternal.setting.open();
-      this.appInternal.setting.openTabById('obsidibot');
+      openPermissionPopover(this.plugin, this.permissionIconEl, this.getEffectivePermissionMode());
     });
     this.updatePermissionIcon();
 

--- a/src/modals/PermissionPickerModal.ts
+++ b/src/modals/PermissionPickerModal.ts
@@ -81,13 +81,17 @@ export function openPermissionPopover(
   const gap = 4;
   const topAbove = rect.top - estimatedHeight - gap;
 
-  popover.style.position = 'fixed';
-  popover.style.left = `${rect.left}px`;
-  if (topAbove >= 8) {
-    popover.style.top = `${topAbove}px`;
-  } else {
-    popover.style.top = `${rect.bottom + gap}px`;
-  }
+  // Set layout/visual properties inline so they win the cascade when appended to document.body,
+  // where Obsidian's base rules have higher specificity than our plugin class.
+  const top = topAbove >= 8 ? topAbove : rect.bottom + gap;
+  popover.setAttribute('style',
+    `position:fixed;left:${rect.left}px;top:${top}px;z-index:9999;` +
+    `background:var(--background-primary);` +
+    `border:1px solid var(--background-modifier-border);` +
+    `border-radius:6px;padding:4px;` +
+    `display:flex;flex-direction:column;gap:2px;min-width:220px;` +
+    `box-shadow:0 6px 20px rgba(0,0,0,0.35);`
+  );
 
   let focusedIndex = PERMISSION_MODES.findIndex(m => m.mode === currentMode);
   if (focusedIndex < 0) focusedIndex = 2;

--- a/src/modals/PermissionPickerModal.ts
+++ b/src/modals/PermissionPickerModal.ts
@@ -1,0 +1,156 @@
+import { App, FuzzySuggestModal, setIcon } from 'obsidian';
+import type ObsidiBotPlugin from '../../main';
+import type { PermissionMode } from '../ClaudeProcess';
+
+interface ModeOption {
+  mode: PermissionMode;
+  icon: string;
+  colorClass: string;
+  label: string;
+  description: string;
+}
+
+export const PERMISSION_MODES: ModeOption[] = [
+  { mode: 'restricted', icon: 'lock',           colorClass: 'obsidibot-perm-restricted', label: 'Chat only',   description: 'web only, no vault access' },
+  { mode: 'readonly',   icon: 'eye',            colorClass: 'obsidibot-perm-readonly',   label: 'Read only',   description: 'read vault, no writes' },
+  { mode: 'standard',   icon: 'shield',         colorClass: 'obsidibot-perm-standard',   label: 'Standard',    description: 'read+write vault, no bash' },
+  { mode: 'full',       icon: 'triangle-alert', colorClass: 'obsidibot-perm-full',       label: 'Full access', description: 'unrestricted, including bash' },
+];
+
+function applyPermission(plugin: ObsidiBotPlugin, mode: PermissionMode): void {
+  plugin.settings.permissionMode = mode;
+  void plugin.saveSettings();
+  plugin.notifyPermissionChanged();
+}
+
+function renderRow(el: HTMLElement, opt: ModeOption, isCurrent: boolean): void {
+  if (isCurrent) el.addClass('obsidibot-perm-row--active');
+  const iconEl = el.createDiv({ cls: `obsidibot-perm-row-icon ${opt.colorClass}` });
+  setIcon(iconEl, opt.icon);
+  const textEl = el.createDiv({ cls: 'obsidibot-perm-row-text' });
+  textEl.createSpan({ cls: 'obsidibot-perm-row-label', text: opt.label });
+  textEl.createSpan({ cls: 'obsidibot-perm-row-desc', text: opt.description });
+}
+
+// ---------------------------------------------------------------------------
+// Ctrl+P modal (FuzzySuggestModal — centered, filterable, keyboard-native)
+// ---------------------------------------------------------------------------
+
+export class PermissionPickerModal extends FuzzySuggestModal<ModeOption> {
+  constructor(
+    app: App,
+    private plugin: ObsidiBotPlugin,
+    private currentMode: PermissionMode,
+  ) {
+    super(app);
+    this.setPlaceholder('Select permission mode…');
+    this.modalEl.addClass('obsidibot-permission-picker-modal');
+  }
+
+  getItems(): ModeOption[] { return PERMISSION_MODES; }
+  getItemText(opt: ModeOption): string { return opt.label; }
+
+  renderSuggestion(fuzzy: { item: ModeOption }, el: HTMLElement): void {
+    el.addClass('obsidibot-perm-row');
+    renderRow(el, fuzzy.item, fuzzy.item.mode === this.currentMode);
+  }
+
+  onChooseItem(opt: ModeOption): void {
+    applyPermission(this.plugin, opt.mode);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Icon-click popover (positioned above the toolbar icon)
+// ---------------------------------------------------------------------------
+
+export function openPermissionPopover(
+  plugin: ObsidiBotPlugin,
+  iconEl: HTMLElement,
+  currentMode: PermissionMode,
+): void {
+  document.querySelector('.obsidibot-perm-popover')?.remove();
+
+  const rect = iconEl.getBoundingClientRect();
+  const popover = document.body.createDiv({ cls: 'obsidibot-perm-popover' });
+
+  // Measure after inserting so we get real height; use an estimate for initial placement.
+  const rowHeight = 44;
+  const padding = 8;
+  const estimatedHeight = PERMISSION_MODES.length * rowHeight + padding;
+  const gap = 4;
+  const topAbove = rect.top - estimatedHeight - gap;
+
+  popover.style.position = 'fixed';
+  popover.style.left = `${rect.left}px`;
+  if (topAbove >= 8) {
+    popover.style.top = `${topAbove}px`;
+  } else {
+    popover.style.top = `${rect.bottom + gap}px`;
+  }
+
+  let focusedIndex = PERMISSION_MODES.findIndex(m => m.mode === currentMode);
+  if (focusedIndex < 0) focusedIndex = 2;
+
+  const rows: HTMLElement[] = [];
+
+  PERMISSION_MODES.forEach((opt, i) => {
+    const row = popover.createDiv({ cls: 'obsidibot-perm-popover-row obsidibot-perm-row' });
+    renderRow(row, opt, opt.mode === currentMode);
+
+    row.addEventListener('mouseenter', () => {
+      focusedIndex = i;
+      updateFocus();
+    });
+
+    row.addEventListener('click', () => {
+      close();
+      applyPermission(plugin, opt.mode);
+    });
+
+    rows.push(row);
+  });
+
+  function updateFocus() {
+    rows.forEach((r, j) => r.toggleClass('obsidibot-perm-popover-row--focused', j === focusedIndex));
+  }
+  updateFocus();
+
+  function close() {
+    popover.remove();
+    document.removeEventListener('keydown', keyHandler, true);
+    document.removeEventListener('mousedown', outsideHandler, true);
+  }
+
+  const keyHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      focusedIndex = (focusedIndex + 1) % PERMISSION_MODES.length;
+      updateFocus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      focusedIndex = (focusedIndex - 1 + PERMISSION_MODES.length) % PERMISSION_MODES.length;
+      updateFocus();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      close();
+      applyPermission(plugin, PERMISSION_MODES[focusedIndex].mode);
+    }
+  };
+
+  const outsideHandler = (e: MouseEvent) => {
+    if (!popover.contains(e.target as Node) && e.target !== iconEl) {
+      close();
+    }
+  };
+
+  // Defer so the icon's own click event doesn't immediately trigger outsideHandler.
+  setTimeout(() => {
+    document.addEventListener('keydown', keyHandler, true);
+    document.addEventListener('mousedown', outsideHandler, true);
+  }, 0);
+}

--- a/styles.css
+++ b/styles.css
@@ -1535,6 +1535,83 @@
 .obsidibot-permission-icon .svg-icon circle,
 .obsidibot-permission-icon .svg-icon rect { stroke-width: 2.5 !important; }
 
+/* ── Permission picker — shared row layout (popover + modal) ── */
+.obsidibot-perm-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.obsidibot-perm-row-icon {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.obsidibot-perm-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.obsidibot-perm-row-label {
+  font-size: var(--font-ui-small);
+  font-weight: 500;
+  color: var(--text-normal);
+  white-space: nowrap;
+}
+
+.obsidibot-perm-row-desc {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.obsidibot-perm-row--active .obsidibot-perm-row-label {
+  color: var(--interactive-accent);
+}
+
+/* ── Permission picker popover (icon click) ── */
+.obsidibot-perm-popover {
+  position: fixed;
+  z-index: 9999;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 220px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.obsidibot-perm-popover-row:hover,
+.obsidibot-perm-popover-row--focused {
+  background: var(--background-modifier-hover);
+}
+
+/* ── Permission picker modal (Ctrl+P) ── */
+.obsidibot-permission-picker-modal .suggestion-item.obsidibot-perm-row {
+  padding: 6px 10px;
+}
+
+.obsidibot-permission-picker-modal .suggestion-item.is-selected .obsidibot-perm-row-label {
+  color: var(--text-on-accent);
+}
+
+.obsidibot-permission-picker-modal .suggestion-item.is-selected .obsidibot-perm-row-desc {
+  color: var(--text-on-accent-muted, var(--text-on-accent));
+  opacity: 0.8;
+}
+
 /* ── Memory audit modal ── */
 .obsidibot-audit-btn-row {
   display: flex;

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -250,14 +250,92 @@ describe('permissionArgs', () => {
     assert.ok(!args[idx + 1].includes('Bash'));
   });
 
+  test('restricted → default mode + web-only allowedTools', () => {
+    const args = permissionArgs('restricted');
+    assert.ok(args.includes('default'));
+    const idx = args.indexOf('--allowedTools');
+    assert.ok(idx !== -1);
+    const tools = args[idx + 1].split(',');
+    assert.ok(tools.includes('WebFetch'));
+    assert.ok(tools.includes('WebSearch'));
+    assert.ok(!tools.includes('Read'));
+    assert.ok(!tools.includes('Write'));
+    assert.ok(!tools.includes('Bash'));
+  });
+
   test('full → bypassPermissions', () => {
     const args = permissionArgs('full');
     assert.ok(args.includes('bypassPermissions'));
   });
 
   test('no mode ever includes dangerously-skip-permissions', () => {
-    for (const mode of ['standard', 'readonly', 'full'] as const) {
+    for (const mode of ['standard', 'readonly', 'full', 'restricted'] as const) {
       assert.ok(!permissionArgs(mode).some(a => a.includes('dangerously')));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permission picker mode table — data-layer invariants
+// ---------------------------------------------------------------------------
+
+describe('permission picker mode table', () => {
+  // Mirror the PERMISSION_MODES data from PermissionPickerModal.ts without
+  // importing the file (which depends on the Obsidian API).
+  type PermissionMode = 'restricted' | 'readonly' | 'standard' | 'full';
+  interface ModeOption {
+    mode: PermissionMode;
+    icon: string;
+    colorClass: string;
+    label: string;
+    description: string;
+  }
+  const EXPECTED_MODES: ModeOption[] = [
+    { mode: 'restricted', icon: 'lock',           colorClass: 'obsidibot-perm-restricted', label: 'Chat only',   description: 'web only, no vault access' },
+    { mode: 'readonly',   icon: 'eye',            colorClass: 'obsidibot-perm-readonly',   label: 'Read only',   description: 'read vault, no writes' },
+    { mode: 'standard',   icon: 'shield',         colorClass: 'obsidibot-perm-standard',   label: 'Standard',    description: 'read+write vault, no bash' },
+    { mode: 'full',       icon: 'triangle-alert', colorClass: 'obsidibot-perm-full',       label: 'Full access', description: 'unrestricted, including bash' },
+  ];
+
+  const ALL_MODES: PermissionMode[] = ['restricted', 'readonly', 'standard', 'full'];
+
+  test('all four permission modes are represented', () => {
+    const modes = EXPECTED_MODES.map(m => m.mode);
+    for (const m of ALL_MODES) {
+      assert.ok(modes.includes(m), `missing mode: ${m}`);
+    }
+    assert.equal(EXPECTED_MODES.length, 4);
+  });
+
+  test('each mode entry has a non-empty icon, colorClass, label, and description', () => {
+    for (const entry of EXPECTED_MODES) {
+      assert.ok(entry.icon.length > 0,       `${entry.mode}: icon is empty`);
+      assert.ok(entry.colorClass.length > 0, `${entry.mode}: colorClass is empty`);
+      assert.ok(entry.label.length > 0,      `${entry.mode}: label is empty`);
+      assert.ok(entry.description.length > 0, `${entry.mode}: description is empty`);
+    }
+  });
+
+  test('color classes use the obsidibot-perm- prefix', () => {
+    for (const entry of EXPECTED_MODES) {
+      assert.ok(entry.colorClass.startsWith('obsidibot-perm-'), `${entry.mode}: colorClass must start with obsidibot-perm-`);
+    }
+  });
+
+  test('each mode maps to a unique label', () => {
+    const labels = EXPECTED_MODES.map(m => m.label);
+    assert.equal(new Set(labels).size, labels.length, 'labels must be unique');
+  });
+
+  test('each mode maps to a unique icon', () => {
+    const icons = EXPECTED_MODES.map(m => m.icon);
+    assert.equal(new Set(icons).size, icons.length, 'icons must be unique');
+  });
+
+  test('permissionArgs handles every mode listed in the picker', () => {
+    for (const entry of EXPECTED_MODES) {
+      const args = permissionArgs(entry.mode);
+      assert.ok(Array.isArray(args) && args.length > 0, `permissionArgs('${entry.mode}') returned no args`);
     }
   });
 });


### PR DESCRIPTION
## Description

Replaces the permission icon's behavior of opening the full settings panel with a focused, inline experience:

**Icon click** → a small popover anchored above the toolbar icon lists the four permission modes. The current mode is highlighted. Supports arrow-key navigation, Enter to confirm, Escape / click-outside to cancel.

**Ctrl+P: ObsidiBot: Change permission mode** → the same four options in a searchable `FuzzySuggestModal` centered in the window.

Both paths call `plugin.notifyPermissionChanged()`, so the change takes effect on the next message turn — identical behavior to editing the setting in the settings panel, including the system-message context injection that informs Claude of the mode change.

The four modes shown, with their colored icons:
| Icon | Mode | Description |
|---|---|---|
| 🔒 lock (blue) | Chat only | web only, no vault access |
| 👁 eye (green) | Read only | read vault, no writes |
| 🛡 shield (yellow) | Standard | read+write vault, no bash |
| ⚠ triangle-alert (red) | Full access | unrestricted, including bash |

New file: `src/modals/PermissionPickerModal.ts`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] **Icon click opens popover above icon** — click the colored permission icon in the input toolbar; a 4-row popover should appear above it
- [ ] **Current mode is highlighted** — the active mode row should be visually distinct (accent color label)
- [ ] **Mouse selection works** — click a different mode row; popover closes and icon color updates immediately
- [ ] **Arrow key navigation** — after opening, use ↑ / ↓ to move focus, Enter to confirm
- [ ] **Escape closes without changing** — open popover, press Escape; mode unchanged
- [ ] **Click outside closes** — open popover, click elsewhere in the UI; mode unchanged
- [ ] **Mode takes effect on next send** — change mode via popover, send a message; verify Claude acknowledges the new mode in its response context
- [ ] **Ctrl+P command** — open command palette, search "Change permission mode"; selecting a mode works identically to the popover
- [ ] **System message injection** — after a mode change via either path, Claude's next turn should receive the `[System: Permission mode changed to …]` context message
- [ ] **Popover positioning** — verify popover appears above the icon, not obscured by the toolbar

**Test Configuration**:
- OS: Windows 11
- Version: 2.14.1
- Obsidian: current

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (72 tests, 0 failures)

## Additional Notes

- `PERMISSION_MODES` in `PermissionPickerModal.ts` is intentionally a plain data array (no Obsidian deps) so it can be tested without mocking Obsidian
- The popover uses `position: fixed` so it escapes any scrolling container and sits correctly above the icon regardless of pane scroll state
- The `mousedown` listener (not `click`) is used for outside-click detection to avoid race conditions with the icon's own click event
- Added a previously missing test for `permissionArgs('restricted')` while adding the new suite