### PR TITLE
fix: remove OS username from welcome screen greeting

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1113,11 +1113,6 @@ export class ClaudeView extends ItemView {
   private renderWelcomeScreen() {
     const { greetings, tips } = welcomeData.welcome;
 
-    // Username from OS, capitalized
-    let name = '';
-    try { name = require('os').userInfo().username; } catch { /* ignore */ }
-    if (name) name = name.charAt(0).toUpperCase() + name.slice(1).toLowerCase();
-
     // Time-of-day bucket
     const hour = new Date().getHours();
     const bucket = hour >= 5 && hour < 12 ? greetings.morning
@@ -1125,11 +1120,9 @@ export class ClaudeView extends ItemView {
       : hour >= 18 && hour < 22 ? greetings.evening
       : greetings.night;
 
-    // Random greeting from bucket
+    // Random greeting from bucket — always anonymous until the user introduces themselves
     const entry = bucket[Math.floor(Math.random() * bucket.length)];
-    const greetingText = name
-      ? entry.withName.replace('{{name}}', name)
-      : entry.withoutName;
+    const greetingText = entry.withoutName;
 
     const tip = tips[Math.floor(Math.random() * tips.length)];
 

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -840,6 +840,12 @@ export class ClaudeView extends ItemView {
       onSetLabel: (userLabel: string, assistantLabel: string) => {
         this.currentUserLabel = userLabel;
         this.currentAssistantLabel = assistantLabel;
+        // Persist cross-session so the welcome screen can greet by name
+        const knownName = userLabel !== 'User' ? userLabel : '';
+        if (this.plugin.settings.userLabel !== knownName) {
+          this.plugin.settings.userLabel = knownName;
+          void this.plugin.saveSettings();
+        }
         const fileId = this.coordinator.sessionFileId;
         if (!fileId) return;
         const vaultRoot = this.plugin.getVaultRoot();
@@ -1120,9 +1126,12 @@ export class ClaudeView extends ItemView {
       : hour >= 18 && hour < 22 ? greetings.evening
       : greetings.night;
 
-    // Random greeting from bucket — always anonymous until the user introduces themselves
+    // Use name only if the user has consensually introduced themselves via conversation
+    const knownName = this.plugin.settings.userLabel?.trim() || '';
     const entry = bucket[Math.floor(Math.random() * bucket.length)];
-    const greetingText = entry.withoutName;
+    const greetingText = knownName
+      ? entry.withName.replace('{{name}}', knownName)
+      : entry.withoutName;
 
     const tip = tips[Math.floor(Math.random() * tips.length)];
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -61,6 +61,8 @@ export interface ObsidiBotSettings {
   persistFullAccess: boolean;
   /** Max characters of canvas text injected as context. 0 = no limit. */
   canvasMaxChars: number;
+  /** User's preferred name, set via conversation (set-label action). Empty = unknown. */
+  userLabel: string;
 }
 
 export const DEFAULT_SETTINGS: ObsidiBotSettings = {
@@ -89,6 +91,7 @@ export const DEFAULT_SETTINGS: ObsidiBotSettings = {
   registerSkillsAsCommands: true,
   persistFullAccess: false,
   canvasMaxChars: 50000,
+  userLabel: '',
 };
 
 export class ObsidiBotSettingsTab extends PluginSettingTab {


### PR DESCRIPTION
The welcome screen was calling `os.userInfo().username` at render time and injecting the result into the greeting — silently reading and displaying the user's OS account name without disclosure or consent.

This PR replaces that with the proper consent-based path that was always the design intent:

- `os.userInfo()` call removed entirely
- When Claude receives a `set-label` action (triggered when the user introduces themselves in conversation), the name is now persisted to `plugin.settings.userLabel`
- `renderWelcomeScreen` reads from `plugin.settings.userLabel` — anonymous greeting on a fresh install, personalised greeting once the user has introduced themselves
- If the user is reset to the default label (`'User'`), the stored name is cleared

The `withName` greeting variants in `welcome.json` are now properly wired up through a consensual path rather than dead code.

## Test plan
- [ ] Fresh install: welcome screen shows anonymous greeting
- [ ] Tell ObsidiBot your name in conversation → Claude emits `set-label` → next new session welcome screen uses the name
- [ ] Restart Obsidian: name persists (stored in `data.json`)
- [ ] All four time-of-day greeting buckets still work