### PR TITLE
feat: folder suggest dropdown for folder-path settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import type ObsidiBotPlugin from '../main';
 import type { PermissionMode } from './ClaudeProcess';
 export type { PermissionMode };
 import { AppInternal } from './obsidianInternal';
+import { FolderSuggest } from './utils/FolderSuggest';
 
 export interface ObsidiBotSettings {
   binaryPath: string;
@@ -269,7 +270,8 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Export folder')
       .setDesc('Vault-relative folder where "export session to vault" saves notes. Created automatically if it does not exist.')
-      .addText((text) =>
+      .addText((text) => {
+        new FolderSuggest(this.app, text.inputEl);
         text
           // eslint-disable-next-line obsidianmd/ui/sentence-case
           .setPlaceholder('ObsidiBot Exports')
@@ -277,8 +279,8 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.exportFolder = value;
             await this.plugin.saveSettings();
-          })
-      );
+          });
+      });
 
     new Setting(containerEl)
       .setName('Session storage path')
@@ -289,15 +291,16 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
         'or an absolute path to store them outside the vault entirely. ' +
         'Restart ObsidiBot after changing this.'
       )
-      .addText((text) =>
+      .addText((text) => {
+        new FolderSuggest(this.app, text.inputEl);
         text
           .setPlaceholder('Default (Obsidian config folder/obsidibot/sessions)')
           .setValue(this.plugin.settings.sessionStoragePath)
           .onChange(async (value) => {
             this.plugin.settings.sessionStoragePath = value.trim();
             await this.plugin.saveSettings();
-          })
-      );
+          });
+      });
 
     new Setting(containerEl)
       .setName('Skills folder')
@@ -307,7 +310,8 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
         'Use a vault-relative path (e.g. _skills) to keep skills in your vault, ' +
         'or an absolute path. Skills reload each time you open the / menu.'
       )
-      .addText((text) =>
+      .addText((text) => {
+        new FolderSuggest(this.app, text.inputEl);
         text
           .setPlaceholder('Default (plugin dir/commands)')
           .setValue(this.plugin.settings.commandsFolder)
@@ -317,8 +321,8 @@ export class ObsidiBotSettingsTab extends PluginSettingTab {
             if (this.plugin.settings.registerSkillsAsCommands) {
               this.plugin.reloadSkillCommands();
             }
-          })
-      );
+          });
+      });
 
     new Setting(containerEl)
       .setName('Register skills as Ctrl+P commands')

--- a/src/utils/FolderSuggest.ts
+++ b/src/utils/FolderSuggest.ts
@@ -1,0 +1,28 @@
+import { AbstractInputSuggest, App, TFolder } from 'obsidian';
+
+export class FolderSuggest extends AbstractInputSuggest<TFolder> {
+  private textInputEl: HTMLInputElement;
+
+  constructor(app: App, inputEl: HTMLInputElement) {
+    super(app, inputEl);
+    this.textInputEl = inputEl;
+  }
+
+  getSuggestions(query: string): TFolder[] {
+    const lower = query.toLowerCase();
+    return this.app.vault
+      .getAllFolders(true)
+      .filter(f => f.path.toLowerCase().includes(lower))
+      .sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  renderSuggestion(folder: TFolder, el: HTMLElement): void {
+    el.setText(folder.path === '/' ? '/ (vault root)' : folder.path);
+  }
+
+  selectSuggestion(folder: TFolder): void {
+    this.setValue(folder.path === '/' ? '' : folder.path);
+    this.textInputEl.dispatchEvent(new Event('input'));
+    this.close();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/utils/FolderSuggest.ts` — a new `AbstractInputSuggest<TFolder>` subclass that attaches a live-filtering vault folder dropdown to any text input
- Wires it into three settings that accept vault folder paths: **Export folder**, **Session storage path**, and **Skills folder**
- Selecting a folder from the dropdown sets the field value and fires the existing `onChange` handler, so save logic is unchanged

## Behavior

- As the user types in any of the three fields, a dropdown lists matching vault folders filtered by substring
- Selecting a folder fills the field; for absolute paths (Session storage path, Skills folder) the user can still type freely — the suggest only shows vault folders
- Vault root is shown as `/ (vault root)` but selects as an empty string (equivalent to clearing the field)

## Test plan

- [ ] Open Settings → ObsidiBot
- [ ] Click into **Export folder** — type partial folder name, confirm dropdown appears and selecting a folder fills the field and saves
- [ ] Same for **Session storage path**
- [ ] Same for **Skills folder**
- [ ] Confirm existing manual typing and save still works normally in all three fields

Closes #225