### PR TITLE
feat: add configurable memory file size cap

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -897,6 +897,7 @@ export class ClaudeView extends ItemView {
       effectiveMode === 'restricted' ? 0 : this.plugin.settings.vaultTreeDepth,
       this.plugin.settings.commandAllowlist,
       effectiveMode,
+      this.plugin.settings.contextFileSizeCapTokens,
     );
     const context = await ctx.buildSessionContext();
     this.coordinator.setPendingSystemMessage(`[System: Session context refreshed at user request.]\n\n${context}`);
@@ -1087,8 +1088,10 @@ export class ClaudeView extends ItemView {
         sessionMode === 'restricted' ? 0 : this.plugin.settings.vaultTreeDepth,
         this.plugin.settings.commandAllowlist,
         sessionMode,
+        this.plugin.settings.contextFileSizeCapTokens,
       );
       const context = await ctx.buildSessionContext();
+      if (ctx.needsCompaction) statusEl.textContent = 'Compacting memory…';
       const promptTokens = estimateTokens(finalPrompt);
       finalPrompt = ctx.injectContext(context, finalPrompt);
       if (context) {

--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -31,6 +31,8 @@ export const PERMISSION_DESCRIPTIONS: Record<PermissionMode, { summary: string; 
 };
 
 export class ContextManager {
+  needsCompaction = false;
+
   constructor(
     private app: App,
     private contextFilePath: string,
@@ -38,6 +40,7 @@ export class ContextManager {
     private vaultTreeDepth: number = 0,
     private commandAllowlist: string[] = [],
     private permissionMode: PermissionMode = 'standard',
+    private contextFileSizeCapTokens: number = 0,
   ) { }
 
   async buildSessionContext(): Promise<string> {
@@ -91,6 +94,16 @@ export class ContextManager {
     if (contextFile) {
       contextFileContent = neutralizeTriggers(await this.app.vault.read(contextFile));
       if (contextFileContent.trim()) {
+        const cap = this.contextFileSizeCapTokens;
+        const contentTokens = estimateTokens(contextFileContent);
+        if (cap > 0 && contentTokens > cap) {
+          this.needsCompaction = true;
+          contextFileContent +=
+            `\n\n[Your memory file is ~${contentTokens} tokens, over your ${cap}-token cap. ` +
+            `Before this session ends, compact it: summarize redundant entries, drop outdated observations, ` +
+            `keep high-signal facts. Write the result back to \`${this.contextFilePath}\`.]`;
+          log(`Context file exceeded cap (${cap} tokens, actual ~${contentTokens}) — compaction instruction injected.`);
+        }
         const ctxBlock = `## Vault context\n${contextFileContent.trim()}`;
         parts.push(ctxBlock);
         layerBreakdown['context-file'] = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,6 +62,8 @@ export interface BojuBotSettings {
   persistFullAccess: boolean;
   /** Max characters of canvas text injected as context. 0 = no limit. */
   canvasMaxChars: number;
+  /** Max tokens of context file content injected at session start. 0 = no limit. */
+  contextFileSizeCapTokens: number;
   /** User's preferred name, set via conversation (set-label action). Empty = unknown. */
   userLabel: string;
 }
@@ -92,6 +94,7 @@ export const DEFAULT_SETTINGS: BojuBotSettings = {
   registerSkillsAsCommands: true,
   persistFullAccess: false,
   canvasMaxChars: 50000,
+  contextFileSizeCapTokens: 0,
   userLabel: '',
 };
 
@@ -225,6 +228,28 @@ export class BojuBotSettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.autonomousMemory)
           .onChange(async (value) => {
             this.plugin.settings.autonomousMemory = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName('Memory file size limit (tokens)')
+      .setDesc(
+        'When your context file exceeds this token count, Claude is instructed to compact it before the session ends — ' +
+        'summarizing redundant entries and dropping outdated observations. ' +
+        'Set to 0 to disable. Typical context files stay well under 4 000 tokens; set a limit if yours grows large over time.'
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder('0 (no limit)')
+          .setValue(
+            this.plugin.settings.contextFileSizeCapTokens === 0
+              ? ''
+              : String(this.plugin.settings.contextFileSizeCapTokens)
+          )
+          .onChange(async (value) => {
+            const n = parseInt(value, 10);
+            this.plugin.settings.contextFileSizeCapTokens = isNaN(n) || n < 0 ? 0 : n;
             await this.plugin.saveSettings();
           })
       );


### PR DESCRIPTION
## Summary

Adds **Memory file size limit (tokens)** setting under Context & Memory in settings.

When the context file exceeds the cap, Claude receives an instruction appended to the injected content asking it to compact the file before the session ends — summarizing redundant entries and dropping outdated observations. The full file is still injected; no content is silently dropped.

Default is `0` (disabled) — no behaviour change for existing users.

## Why not truncate?

The file is structured Markdown. A naive slice destroys section structure, uses the wrong priority heuristic (oldest ≠ least valuable), and loses content silently. Letting Claude compact it means the right things get kept.

## Test plan

- [ ] Set cap to a small value, open a session with a non-trivial context file — confirm the compaction instruction appears at the end of the injected vault context block
- [ ] Set cap to 0 — confirm full context is injected with no instruction appended
- [ ] Context refresh (command palette) also respects the cap
- [ ] Build passes with no TypeScript errors