### PR TITLE
fix: add missing colons to CSS properties in custom.css

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -38,10 +38,10 @@ body {
 }
 
 .footer {
-    margin-top 40px;
-    padding-bottom 8px;
-    padding-top 40px;
-    position relative;
+    margin-top: 40px;
+    padding-bottom: 8px;
+    padding-top: 40px;
+    position: relative;
 }
 
 h1 {


### PR DESCRIPTION
## Summary

Four property declarations in the `.footer` rule in `assets/css/custom.css` were missing colons, making them invalid CSS. The Obsidian community plugin linter flagged `margin-top` as an unknown word because without the colon it can't be parsed as a property declaration.

```css
/* Before */
margin-top 40px;
padding-bottom 8px;
padding-top 40px;
position relative;

/* After */
margin-top: 40px;
padding-bottom: 8px;
padding-top: 40px;
position: relative;
```

## Test plan

- [ ] Obsidian community plugin linter passes