### PR TITLE
fix: address Obsidian submission lint warnings

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,6 +1,5 @@
 body {
     background-color: rgb(10, 12, 16);
-    margin-bottom: 0;
     margin-top: 0;
 
     border-bottom-color: rgb(122, 130, 142);
@@ -176,7 +175,7 @@ code {
     white-space: break-saces;
     background-color: rgba(158, 167, 179, 0.4);
     border-radius: 6px;
-    font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+    font-family: SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
     box-sizing: border-box;
     line-height: 1.5;
     word-wrap: break-word;

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
-import builtins from "builtin-modules";
+import { builtinModules } from "module";
 
 const prod = process.argv[2] === "production";
 
@@ -22,7 +22,7 @@ const context = await esbuild.context({
     "@lezer/common",
     "@lezer/highlight",
     "@lezer/lr",
-    ...builtins,
+    ...builtinModules,
   ],
   format: "cjs",
   target: "es2018",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "bojubot",
-  "version": "2.15.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bojubot",
-      "version": "2.15.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.0.0",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.0",
-        "builtin-modules": "^3.3.0",
         "esbuild": "^0.21.0",
         "eslint-plugin-obsidianmd": "^0.2.4",
         "obsidian": "latest",
@@ -3179,19 +3178,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/builtin-modules": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/call-bind": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.0",
-    "builtin-modules": "^3.3.0",
     "esbuild": "^0.21.0",
     "eslint-plugin-obsidianmd": "^0.2.4",
     "obsidian": "latest",
@@ -26,6 +25,5 @@
     "tsx": "^4.21.0",
     "typescript": "^5.3.0",
     "vitepress": "^1.6.4"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
## Summary

- Replace `builtin-modules` dev dependency with Node's native `module.builtinModules` — same behavior, no third-party package needed
- Remove duplicate `margin-bottom: 0` from `assets/css/custom.css` body rule (was overridden by `margin-bottom: -1px` below it)
- Remove `ui-monospace` from `assets/css/custom.css` code font stack — flagged as unsupported extended-system-font; fallbacks cover identical platforms

## Test plan

- [ ] Plugin loads in test vault without errors
- [ ] `npm run build` passes (verified before commit)