### PR TITLE
feat: add model switcher with toolbar indicator and /model command

### DIFF
--- a/docs/guide/chat-panel.md
+++ b/docs/guide/chat-panel.md
@@ -58,6 +58,24 @@ Click it to open a quick picker and switch modes. The change takes effect on the
 
 ---
 
+## Model Indicator
+
+The **model name** shown in the input toolbar (e.g. *Claude Sonnet*) reflects the active Claude model. Click it to open the model picker and switch to a different model.
+
+| Model          | Best for                              |
+| -------------- | ------------------------------------- |
+| Claude Haiku   | Fast responses, simple tasks          |
+| Claude Sonnet  | Balanced speed and capability         |
+| Claude Opus    | Complex reasoning and long tasks      |
+
+Switching models starts a **new session** — the current conversation cannot continue with a different model. The selected model persists across restarts.
+
+You can also switch via `/model` in the slash menu or **BojuBot: Switch model** in the Command Palette.
+
+To add models not in the built-in list, see [Custom models](./settings.md#custom-models) in Settings.
+
+---
+
 ## Context Gauge
 
 A **ring icon** appears in the input bar after your first message. Hover to see how much of the 200K token context window remains. Click it to manually compact the session history if it's filling up.

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -25,6 +25,34 @@ Open **Settings → BojuBot** to configure:
 | **@-mention file types**           | `*` (all vault files)                                | Comma-separated extensions for the `@` autocomplete dropdown. `*` includes all vault files. To restrict, list extensions explicitly (e.g. `md, pdf, txt`). Add a trailing comma to also match files with no extension (e.g. `md, txt,`).       |
 | **Inject split-pane files**        | On                                                   | When in split-pane view, include all visible file paths as active note context.                                                                                                                                                                |
 
+## Custom models
+
+BojuBot ships with a hardcoded list of Claude models (Haiku, Sonnet, Opus). When new models are released you can add them without waiting for a plugin update by creating a file at:
+
+```
+<vault>/.obsidian/plugins/bojubot/custom-models.json
+```
+
+The file is a JSON array of model objects. Any valid entries are appended to the built-in list in the `/model` picker:
+
+```json
+[
+  {
+    "id": "claude-sonnet-4-7",
+    "displayName": "Claude Sonnet 4.7",
+    "description": "Latest Sonnet model"
+  }
+]
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | Yes | Full model ID passed to `--model` at spawn time |
+| `displayName` | Yes | Name shown in the picker |
+| `description` | No | Short note shown below the name |
+
+The file is read each time the picker opens, so changes take effect immediately with no restart needed. If the file is missing or malformed, it is silently ignored and only the built-in models are shown.
+
 ## Session storage location
 
 By default, session files are stored in `.obsidian/bojubot/sessions/` inside your vault. This folder is typically gitignored, so sessions don't appear in your git history.

--- a/docs/guide/slash-commands.md
+++ b/docs/guide/slash-commands.md
@@ -19,6 +19,7 @@ The `/` menu gives you quick access to built-in BojuBot actions and your own **s
 | **Session** | New session       | Start a fresh conversation               |
 | **Session** | Show history      | Browse and resume past sessions          |
 | **Session** | Export session    | Save the current session to your vault   |
+| **Session** | Switch model      | Pick the Claude model for new sessions   |
 | **Context** | Attach file       | Add a file, image, or URL to the prompt  |
 | **Context** | Open context file | Edit your persistent vault context       |
 | **Context** | Refresh context   | Re-inject vault context into the session |

--- a/main.ts
+++ b/main.ts
@@ -228,6 +228,22 @@ export default class BojuBotPlugin extends Plugin {
     });
 
     this.addCommand({
+      id: 'switch-model',
+      name: 'Switch model',
+      callback: () => {
+        const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDE);
+        if (existing.length) {
+          (existing[0].view as ClaudeView).openModelPicker();
+        } else {
+          void this.activateView().then(() => {
+            const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDE);
+            if (leaves.length) (leaves[0].view as ClaudeView).openModelPicker();
+          });
+        }
+      },
+    });
+
+    this.addCommand({
       id: 'reload-skills',
       name: 'Reload skills',
       callback: () => {

--- a/src/ClaudeProcess.ts
+++ b/src/ClaudeProcess.ts
@@ -94,6 +94,7 @@ export interface SpawnOptions {
   env: Record<string, string>;
   resumeSessionId?: string;
   permissionMode?: PermissionMode;
+  model?: string;
 }
 
 export function spawnClaude(opts: SpawnOptions): ChildProcess {
@@ -103,6 +104,10 @@ export function spawnClaude(opts: SpawnOptions): ChildProcess {
     '--print',
     ...permissionArgs(opts.permissionMode ?? 'standard'),
   ];
+
+  if (opts.model) {
+    args.push('--model', opts.model);
+  }
 
   if (opts.resumeSessionId) {
     args.push('--resume', opts.resumeSessionId);

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -9,6 +9,8 @@ import { SlashParamModal } from './modals/SlashParamModal';
 import { openPermissionPopover } from './modals/PermissionPickerModal';
 import { AtMentionController } from './AtMentionController';
 import { spawn } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import { SkillDef, resolveSkillsFolder, loadSkills, parseSkillFile, nameFromPath } from './SkillLoader';
 import type BojuBotPlugin from '../main';
 import { findClaudeBinary, PermissionDenial, PermissionMode } from './ClaudeProcess';
@@ -18,6 +20,7 @@ import { VaultQuery, VaultQueryResult, resolveQuery, queryLabel, buildInjectMess
 import { BOJU_PREFIX, neutralizeTriggers } from './constants';
 import { ContextManager, PERMISSION_DESCRIPTIONS } from './ContextManager';
 import { log, estimateTokens } from './utils/logger';
+import { CLAUDE_MODELS, ClaudeModel } from './settings';
 import { extractToolDetail } from './utils/toolFormatting';
 import {
   StoredSession,
@@ -122,6 +125,7 @@ export class ClaudeView extends ItemView {
   private tokenGauge: TokenGauge;
   private attachPopoverEl: HTMLElement;
   private permissionIconEl!: HTMLButtonElement;
+  private modelIndicatorEl!: HTMLElement;
   private currentUserLabel = 'User';
   private currentAssistantLabel = 'BojuBot';
 
@@ -134,6 +138,7 @@ export class ClaudeView extends ItemView {
       getConfigDir: () => this.app.vault.configDir,
       getEnv: () => this.plugin.shellEnv,
       getPermissionMode: () => this.plugin.settings.permissionMode,
+      getModel: () => this.plugin.settings.defaultModel,
       getSessionsDir: () => this.getSessionsDir(),
       saveLastActiveSessionId: async (id) => {
         this.plugin.settings.lastActiveSessionId = id;
@@ -441,6 +446,11 @@ export class ClaudeView extends ItemView {
       openPermissionPopover(this.plugin, this.permissionIconEl, this.getEffectivePermissionMode());
     });
     this.updatePermissionIcon();
+
+    this.modelIndicatorEl = inputToolbar.createEl('span', { cls: 'bojubot-model-indicator' });
+    this.modelIndicatorEl.title = 'Switch model';
+    this.modelIndicatorEl.addEventListener('click', () => this.openModelPicker());
+    this.updateModelIndicator();
 
     inputToolbar.createDiv({ cls: 'bojubot-input-toolbar-spacer' });
 
@@ -1152,6 +1162,10 @@ export class ClaudeView extends ItemView {
     headerLogo.draggable = false;
     header.createSpan({ cls: 'bojubot-welcome-header-name', text: 'BojuBot' });
     header.createSpan({ cls: 'bojubot-welcome-version', text: `v${this.plugin.manifest.version}` });
+    const activeModel = CLAUDE_MODELS.find(m => m.id === this.plugin.settings.defaultModel);
+    if (activeModel) {
+      header.createSpan({ cls: 'bojubot-welcome-model', text: activeModel.displayName });
+    }
 
     // Centered body: sprite + greeting + tip
     const body = welcome.createDiv({ cls: 'bojubot-welcome-body' });
@@ -1771,8 +1785,37 @@ export class ClaudeView extends ItemView {
     }));
   }
 
+  private updateModelIndicator() {
+    if (!this.modelIndicatorEl) return;
+    const active = CLAUDE_MODELS.find(m => m.id === this.plugin.settings.defaultModel);
+    this.modelIndicatorEl.setText(active?.displayName ?? 'Claude Sonnet');
+  }
+
+  openModelPicker() {
+    const customModelsPath = join(
+      this.plugin.getVaultRoot(),
+      this.app.vault.configDir,
+      'plugins', 'bojubot', 'custom-models.json',
+    );
+    const allModels = [...CLAUDE_MODELS, ...loadCustomModels(customModelsPath)];
+
+    new ModelPickerModal(this.app, this.plugin.settings.defaultModel, allModels, async (model) => {
+      this.plugin.settings.defaultModel = model.id;
+      await this.plugin.saveSettings();
+      this.updateModelIndicator();
+      this.appendMessage('system', `Switching to ${model.displayName} — starting new session.`);
+      this.startNewSession();
+    }).open();
+  }
+
   private buildCommands(): SlashCommand[] {
     return [
+      {
+        category: 'Session',
+        name: 'Switch model',
+        description: 'Choose which Claude model to use',
+        action: () => this.openModelPicker(),
+      },
       {
         category: 'Session',
         name: 'New session',
@@ -1842,6 +1885,61 @@ export class ClaudeView extends ItemView {
 // ---------------------------------------------------------------------------
 // Attach modals
 // ---------------------------------------------------------------------------
+
+function loadCustomModels(filePath: string): ClaudeModel[] {
+  if (!existsSync(filePath)) return [];
+  try {
+    const raw = JSON.parse(readFileSync(filePath, 'utf8'));
+    if (!Array.isArray(raw)) return [];
+    return raw.filter(
+      (e): e is ClaudeModel =>
+        e && typeof e.id === 'string' && e.id.trim() !== '' &&
+        typeof e.displayName === 'string' && e.displayName.trim() !== '',
+    ).map(e => ({
+      id: e.id.trim(),
+      displayName: e.displayName.trim(),
+      description: typeof e.description === 'string' ? e.description.trim() : '',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+class ModelPickerModal extends Modal {
+  constructor(
+    app: App,
+    private currentModelId: string,
+    private models: ClaudeModel[],
+    private onSelect: (model: ClaudeModel) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen() {
+    this.titleEl.setText('Switch model');
+    this.contentEl.addClass('bojubot-model-picker');
+
+    for (const model of this.models) {
+      const row = this.contentEl.createDiv({ cls: 'bojubot-model-row' });
+      if (model.id === this.currentModelId) row.addClass('is-active');
+
+      const text = row.createDiv({ cls: 'bojubot-model-text' });
+      text.createDiv({ cls: 'bojubot-model-name', text: model.displayName });
+      text.createDiv({ cls: 'bojubot-model-desc', text: model.description });
+
+      if (model.id === this.currentModelId) {
+        row.createDiv({ cls: 'bojubot-model-check', text: '✓' });
+      }
+
+      row.addEventListener('click', () => {
+        this.onSelect(model);
+        this.close();
+      });
+    }
+  }
+
+  onClose() { this.contentEl.empty(); }
+}
 
 class AttachUrlModal extends Modal {
   constructor(app: App, private onSubmit: (url: string) => void) {

--- a/src/SessionCoordinator.ts
+++ b/src/SessionCoordinator.ts
@@ -30,6 +30,7 @@ export interface SessionCoordinatorHost {
   getConfigDir(): string;
   getEnv(): Record<string, string>;
   getPermissionMode(): PermissionMode;
+  getModel(): string;
   getSessionsDir(): string;
   saveLastActiveSessionId(id: string): Promise<void>;
   isUiBridgeEnabled(): boolean;
@@ -237,6 +238,7 @@ export class SessionCoordinator {
         env: this.host.getEnv(),
         resumeSessionId: this._sessionId,
         permissionMode: this._permissionOverride ?? this.host.getPermissionMode(),
+        model: this.host.getModel() || undefined,
       });
       this._activeProc = proc;
     } catch (e) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,18 @@ export type { PermissionMode };
 import { AppInternal } from './obsidianInternal';
 import { FolderSuggest } from './utils/FolderSuggest';
 
+export interface ClaudeModel {
+  id: string;
+  displayName: string;
+  description: string;
+}
+
+export const CLAUDE_MODELS: ClaudeModel[] = [
+  { id: 'claude-haiku-4-5-20251001', displayName: 'Claude Haiku', description: 'Fastest — great for quick tasks' },
+  { id: 'claude-sonnet-4-6', displayName: 'Claude Sonnet', description: 'Balanced speed and capability (default)' },
+  { id: 'claude-opus-4-7', displayName: 'Claude Opus', description: 'Most capable — best for complex reasoning' },
+];
+
 export interface BojuBotSettings {
   binaryPath: string;
   contextFilePath: string;
@@ -68,6 +80,8 @@ export interface BojuBotSettings {
   minimalMode: boolean;
   /** User's preferred name, set via conversation (set-label action). Empty = unknown. */
   userLabel: string;
+  /** Claude model ID passed via --model at spawn time. Empty = Claude default (Sonnet). */
+  defaultModel: string;
 }
 
 export const DEFAULT_SETTINGS: BojuBotSettings = {
@@ -99,6 +113,7 @@ export const DEFAULT_SETTINGS: BojuBotSettings = {
   contextFileSizeCapTokens: 0,
   minimalMode: false,
   userLabel: '',
+  defaultModel: '',
 };
 
 export class BojuBotSettingsTab extends PluginSettingTab {

--- a/styles.css
+++ b/styles.css
@@ -124,7 +124,7 @@
 }
 
 .bojubot-input-toolbar-btn {
-  opacity: 0.65;
+  opacity: 1;
 }
 
 .bojubot-permission-icon {
@@ -212,6 +212,67 @@
 .bojubot-send:hover:not(:disabled) {
   background: var(--interactive-accent);
   color: var(--text-on-accent);
+}
+
+/* ── Model indicator (input toolbar) ── */
+.bojubot-model-indicator {
+  font-size: 0.72em;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.bojubot-model-indicator:hover {
+  color: var(--text-normal);
+}
+
+/* ── Model picker modal ── */
+.bojubot-model-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 0;
+  min-width: 280px;
+}
+
+.bojubot-model-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.bojubot-model-row:hover {
+  background: var(--background-modifier-hover);
+}
+
+.bojubot-model-row.is-active {
+  background: var(--background-modifier-hover);
+}
+
+.bojubot-model-text {
+  flex: 1;
+}
+
+.bojubot-model-name {
+  font-weight: 500;
+  color: var(--text-normal);
+  font-size: 0.9em;
+}
+
+.bojubot-model-desc {
+  font-size: 0.78em;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+.bojubot-model-check {
+  color: var(--interactive-accent);
+  font-size: 0.9em;
 }
 
 /* ── About modal ── */
@@ -615,6 +676,17 @@
 .bojubot-welcome-version {
   font-size: 0.72em;
   color: var(--text-faint);
+}
+
+.bojubot-welcome-model {
+  font-size: 0.72em;
+  color: var(--text-faint);
+  margin-left: 4px;
+}
+
+.bojubot-welcome-model::before {
+  content: '·';
+  margin-right: 4px;
 }
 
 .bojubot-welcome-body {


### PR DESCRIPTION
## Summary

- Adds a clickable model name label in the input toolbar (between the permission icon and the spacer) showing the active Claude model
- Click opens a model picker; also accessible via `/model` slash command and **BojuBot: Switch model** in the Command Palette
- Switching models starts a new session and persists the selection across restarts
- Built-in models: Haiku, Sonnet, Opus
- Custom models can be appended via `.obsidian/plugins/bojubot/custom-models.json` — no plugin update required
- Raised input toolbar icon/text brightness for visual consistency across all toolbar elements

## Test plan

- [ ] Model name appears in the toolbar between permission icon and spacer
- [ ] Clicking the model name opens the picker
- [ ] `/model` slash command opens the picker
- [ ] **BojuBot: Switch model** in Command Palette opens the picker
- [ ] Selecting a model shows a system message and starts a new session
- [ ] Selection persists after closing and reopening Obsidian
- [ ] Custom models JSON appends to built-in list when present; missing/malformed file is silently ignored
- [ ] Toolbar paperclip, slash, and send icons are visually consistent brightness with the permission icon