### PR TITLE
fix: lint violations — prime session changes + community bot warnings

### DIFF
--- a/src/AtMentionController.ts
+++ b/src/AtMentionController.ts
@@ -68,7 +68,7 @@ export class AtMentionController {
   /** Call from textarea 'blur' event. */
   handleBlur(): void {
     // Delay so mousedown on a dropdown item fires before the dropdown hides.
-    setTimeout(() => this.hide(), 150);
+    window.setTimeout(() => this.hide(), 150);
   }
 
   /**

--- a/src/AttachmentHandler.ts
+++ b/src/AttachmentHandler.ts
@@ -2,6 +2,7 @@ import { setIcon } from 'obsidian';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { canvasToText } from './utils/canvasParser';
+import { getElectronClipboard } from './utils/electronUtils';
 
 export type PendingContext = {
   text: string;
@@ -73,7 +74,7 @@ export class AttachmentHandler {
   }
 
   openFilePicker(): void {
-    const input = document.createElement('input');
+    const input = activeDocument.createElement('input');
     input.type = 'file';
     input.onchange = async () => {
       const f = input.files?.[0];
@@ -105,8 +106,8 @@ export class AttachmentHandler {
     // Use Electron's clipboard API to get real file paths when a file was
     // copied from Explorer. Works even with context isolation unlike file.path.
     try {
-      const { clipboard } = require('electron') as { clipboard: { readFilePaths(): string[] } };
-      const filePaths = clipboard.readFilePaths();
+      const clipboard = getElectronClipboard();
+      const filePaths = clipboard?.readFilePaths() ?? [];
       if (filePaths.length > 0) {
         let handled = false;
         for (const filePath of filePaths) {

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1842,12 +1842,13 @@ export class ClaudeView extends ItemView {
     );
     const allModels = [...CLAUDE_MODELS, ...loadCustomModels(customModelsPath)];
 
-    new ModelPickerModal(this.app, this.plugin.settings.defaultModel, allModels, async (model) => {
+    new ModelPickerModal(this.app, this.plugin.settings.defaultModel, allModels, (model) => {
       this.plugin.settings.defaultModel = model.id;
-      await this.plugin.saveSettings();
-      this.updateModelIndicator();
-      this.appendMessage('system', `Switching to ${model.displayName} — starting new session.`);
-      this.startNewSession();
+      void this.plugin.saveSettings().then(() => {
+        this.updateModelIndicator();
+        this.appendMessage('system', `Switching to ${model.displayName} — starting new session.`);
+        this.startNewSession();
+      });
     }).open();
   }
 

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1330,7 +1330,7 @@ export class ClaudeView extends ItemView {
             : 'Still not found. Make sure claude is on your PATH, then restart Obsidian.',
           cls: 'bojubot-setup-error',
         });
-        setTimeout(() => err.remove(), 6000);
+        window.setTimeout(() => err.remove(), 6000);
       }
     });
   }
@@ -1453,7 +1453,7 @@ export class ClaudeView extends ItemView {
     copyBtn.addEventListener('click', () => {
       void navigator.clipboard.writeText(code).then(() => {
         copyBtn.setText('Copied!');
-        setTimeout(() => copyBtn.setText('Copy'), 2000);
+        window.setTimeout(() => copyBtn.setText('Copy'), 2000);
       });
     });
   }
@@ -1475,7 +1475,7 @@ export class ClaudeView extends ItemView {
         this.closeAttachPopover();
       }
     };
-    setTimeout(() => document.addEventListener('click', this.attachClickOutside), 0);
+    window.setTimeout(() => activeDocument.addEventListener('click', this.attachClickOutside), 0);
   }
 
   private closeAttachPopover() {
@@ -1484,7 +1484,7 @@ export class ClaudeView extends ItemView {
       ?.querySelector('.bojubot-icon-btn.is-active')
       ?.classList.remove('is-active');
     if (this.attachClickOutside) {
-      document.removeEventListener('click', this.attachClickOutside);
+      activeDocument.removeEventListener('click', this.attachClickOutside);
       this.attachClickOutside = null;
     }
   }
@@ -1999,7 +1999,7 @@ class AttachUrlModal extends Modal {
       if (e.key === 'Enter') { const v = input.value.trim(); if (v) { this.onSubmit(v); this.close(); } }
       if (e.key === 'Escape') this.close();
     });
-    setTimeout(() => input.focus(), 50);
+    window.setTimeout(() => input.focus(), 50);
   }
   onClose() { this.contentEl.empty(); }
 }

--- a/src/ContextGenerationModal.ts
+++ b/src/ContextGenerationModal.ts
@@ -264,7 +264,7 @@ class UserIntroModal extends Modal {
     const cancelBtn = btnRow.createEl('button', { text: 'Cancel' });
     cancelBtn.addEventListener('click', () => this.close());
 
-    setTimeout(() => ta.focus(), 50);
+    window.setTimeout(() => ta.focus(), 50);
   }
 
   private renderChips() {

--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -69,9 +69,9 @@ export class ContextManager {
       // cwd is outside the vault entirely — absolute path is fine, no vault info leaked
       cwdDisplay = this.cwd;
     }
-    const cwdInstruction = (this.cwd && this.cwd !== this.vaultRoot)
-      ? 'Treat your CWD as your working root. Never autonomously infer or declare a vault root, project root, or repository root from directory structure or markers (e.g. .obsidian, .git). If the user explicitly asks you to look at a parent directory, you may do so.'
-      : '';
+    // eslint-disable-next-line obsidianmd/hardcoded-config-path -- instructional text, not a path reference
+    const CWD_BOUNDARY = 'Treat your CWD as your working root. Never autonomously infer or declare a vault root, project root, or repository root from directory structure or markers (e.g. .obsidian, .git). If the user explicitly asks you to look at a parent directory, you may do so.';
+    const cwdInstruction = (this.cwd && this.cwd !== this.vaultRoot) ? CWD_BOUNDARY : '';
 
     let orientation = orientationTemplate
       .replace('{{CWD}}', cwdDisplay)

--- a/src/SlashMenu.ts
+++ b/src/SlashMenu.ts
@@ -63,7 +63,7 @@ export class SlashMenu {
       }
     };
     // Use setTimeout so the click that opened the menu doesn't immediately close it
-    setTimeout(() => document.addEventListener('mousedown', this.outsideClickHandler), 0);
+    window.setTimeout(() => activeDocument.addEventListener('mousedown', this.outsideClickHandler), 0);
   }
 
   open() {
@@ -74,7 +74,7 @@ export class SlashMenu {
   }
 
   close() {
-    document.removeEventListener('mousedown', this.outsideClickHandler);
+    activeDocument.removeEventListener('mousedown', this.outsideClickHandler);
     this.el.remove();
     this.onDismiss();
   }

--- a/src/TokenGauge.ts
+++ b/src/TokenGauge.ts
@@ -30,21 +30,21 @@ export class TokenGauge {
   build(inputToolbar: HTMLElement, inputArea: HTMLElement): void {
     const NS = 'http://www.w3.org/2000/svg';
     const R = 7, C = R * 2 * Math.PI;
-    const svg = document.createElementNS(NS, 'svg') as SVGElement;
+    const svg = activeDocument.createElementNS(NS, 'svg') as SVGElement;
     svg.setAttribute('width', '18');
     svg.setAttribute('height', '18');
     svg.setAttribute('viewBox', '0 0 18 18');
     svg.classList.add('bojubot-token-gauge', 'bojubot-hidden');
 
-    const svgTitle = document.createElementNS(NS, 'title');
+    const svgTitle = activeDocument.createElementNS(NS, 'title');
     svg.appendChild(svgTitle);
 
-    const track = document.createElementNS(NS, 'circle');
+    const track = activeDocument.createElementNS(NS, 'circle');
     track.setAttribute('cx', '9'); track.setAttribute('cy', '9'); track.setAttribute('r', String(R));
     track.classList.add('bojubot-gauge-track');
     svg.appendChild(track);
 
-    const arc = document.createElementNS(NS, 'circle');
+    const arc = activeDocument.createElementNS(NS, 'circle');
     arc.setAttribute('cx', '9'); arc.setAttribute('cy', '9'); arc.setAttribute('r', String(R));
     arc.classList.add('bojubot-gauge-arc');
     arc.setAttribute('stroke-dasharray', String(C));

--- a/src/UIBridge.ts
+++ b/src/UIBridge.ts
@@ -160,7 +160,7 @@ export async function executeAction(app: App, action: BojuBotAction, options: UI
       if (file) {
         const leaf = app.workspace.getLeaf(false);
         await leaf.openFile(file);
-        requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
           const view = leaf.view as unknown as { editor?: { getValue(): string; setCursor(pos: { line: number; ch: number }): void } };
           const editor = view?.editor;
           if (editor && action.heading) {

--- a/src/modals/ExportToVaultModal.ts
+++ b/src/modals/ExportToVaultModal.ts
@@ -46,7 +46,7 @@ export class ExportToVaultModal extends Modal {
       if (e.key === 'Escape') { this.close(); }
     });
 
-    setTimeout(() => { input.focus(); input.select(); }, 50);
+    window.setTimeout(() => { input.focus(); input.select(); }, 50);
   }
 
   onClose() { this.contentEl.empty(); }

--- a/src/modals/PermissionPickerModal.ts
+++ b/src/modals/PermissionPickerModal.ts
@@ -69,10 +69,10 @@ export function openPermissionPopover(
   iconEl: HTMLElement,
   currentMode: PermissionMode,
 ): void {
-  document.querySelector('.bojubot-perm-popover')?.remove();
+  activeDocument.querySelector('.bojubot-perm-popover')?.remove();
 
   const rect = iconEl.getBoundingClientRect();
-  const popover = document.body.createDiv({ cls: 'bojubot-perm-popover' });
+  const popover = activeDocument.body.createDiv({ cls: 'bojubot-perm-popover' });
 
   // Measure after inserting so we get real height; use an estimate for initial placement.
   const rowHeight = 44;
@@ -122,8 +122,8 @@ export function openPermissionPopover(
 
   function close() {
     popover.remove();
-    document.removeEventListener('keydown', keyHandler, true);
-    document.removeEventListener('mousedown', outsideHandler, true);
+    activeDocument.removeEventListener('keydown', keyHandler, true);
+    activeDocument.removeEventListener('mousedown', outsideHandler, true);
   }
 
   const keyHandler = (e: KeyboardEvent) => {
@@ -153,8 +153,8 @@ export function openPermissionPopover(
   };
 
   // Defer so the icon's own click event doesn't immediately trigger outsideHandler.
-  setTimeout(() => {
-    document.addEventListener('keydown', keyHandler, true);
-    document.addEventListener('mousedown', outsideHandler, true);
+  window.setTimeout(() => {
+    activeDocument.addEventListener('keydown', keyHandler, true);
+    activeDocument.addEventListener('mousedown', outsideHandler, true);
   }, 0);
 }

--- a/src/modals/PrimeSessionModal.ts
+++ b/src/modals/PrimeSessionModal.ts
@@ -2,6 +2,7 @@ import { App, FuzzySuggestModal, Modal, TFile, setIcon } from 'obsidian';
 import type { PendingContext } from '../AttachmentHandler';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
+import { getElectronDialog } from '../utils/electronUtils';
 
 export interface PrimeSessionOptions {
   name: string;
@@ -59,7 +60,7 @@ export class PrimeSessionModal extends Modal {
         attr: { type: 'text', placeholder: 'E.g. Screenplay review — act 2' },
       });
       input.addEventListener('input', () => { this.name = input.value; });
-      setTimeout(() => input.focus(), 50);
+      window.setTimeout(() => input.focus(), 50);
     }
 
     // ── Working directory ─────────────────────────────────────────────────────
@@ -79,16 +80,12 @@ export class PrimeSessionModal extends Modal {
       pickBtn.title = 'Browse…';
       pickBtn.addEventListener('click', () => {
         void (async () => {
-          try {
-            const { dialog } = (require('electron') as { remote?: { dialog: ElectronDialog }; dialog?: ElectronDialog }).remote
-              ?? (require('@electron/remote') as { dialog: ElectronDialog });
-            const result = await dialog.showOpenDialog({ properties: ['openDirectory'], defaultPath: this.vaultRoot });
-            if (!result.canceled && result.filePaths[0]) {
-              input.value = result.filePaths[0];
-              this.cwd = result.filePaths[0];
-            }
-          } catch {
-            // Electron dialog unavailable — user can type the path manually
+          const dialog = getElectronDialog();
+          if (!dialog) return;
+          const result = await dialog.showOpenDialog({ properties: ['openDirectory'], defaultPath: this.vaultRoot });
+          if (!result.canceled && result.filePaths[0]) {
+            input.value = result.filePaths[0];
+            this.cwd = result.filePaths[0];
           }
         })();
       });
@@ -168,7 +165,7 @@ export class PrimeSessionModal extends Modal {
   // ── Attachment helpers ────────────────────────────────────────────────────
 
   private pickFile(): void {
-    const input = document.createElement('input');
+    const input = activeDocument.createElement('input');
     input.type = 'file';
     input.onchange = async () => {
       const f = input.files?.[0];
@@ -219,7 +216,7 @@ export class PrimeSessionModal extends Modal {
 
     // Insert before the attach list
     if (this.attachListEl) container.insertBefore(row, this.attachListEl);
-    setTimeout(() => input.focus(), 20);
+    window.setTimeout(() => input.focus(), 20);
   }
 
   private renderAttachments(): void {
@@ -247,11 +244,6 @@ export class PrimeSessionModal extends Modal {
     writeFileSync(filePath, Buffer.from(data));
     return filePath;
   }
-}
-
-// Minimal Electron dialog type — avoids importing the full electron types
-interface ElectronDialog {
-  showOpenDialog(opts: { properties: string[]; defaultPath?: string }): Promise<{ canceled: boolean; filePaths: string[] }>;
 }
 
 class NotePicker extends FuzzySuggestModal<TFile> {

--- a/src/modals/PrimeSessionModal.ts
+++ b/src/modals/PrimeSessionModal.ts
@@ -56,7 +56,7 @@ export class PrimeSessionModal extends Modal {
       field.createEl('div', { text: 'Leave blank to use the first message as title', cls: 'bojubot-param-desc' });
       const input = field.createEl('input', {
         cls: 'bojubot-param-input',
-        attr: { type: 'text', placeholder: 'e.g. Screenplay review — Act 2' },
+        attr: { type: 'text', placeholder: 'E.g. Screenplay review — act 2' },
       });
       input.addEventListener('input', () => { this.name = input.value; });
       setTimeout(() => input.focus(), 50);
@@ -70,25 +70,27 @@ export class PrimeSessionModal extends Modal {
       const row = field.createDiv({ cls: 'bojubot-prime-cwd-row' });
       const input = row.createEl('input', {
         cls: 'bojubot-param-input bojubot-prime-cwd-input',
-        attr: { type: 'text', placeholder: 'e.g. C:\\Projects\\my-repo' },
+        attr: { type: 'text', placeholder: 'E.g. C:\\projects\\my-repo' },
       });
       input.addEventListener('input', () => { this.cwd = input.value; });
 
       const pickBtn = row.createEl('button', { cls: 'bojubot-prime-cwd-btn', attr: { type: 'button' } });
       setIcon(pickBtn, 'folder-open');
       pickBtn.title = 'Browse…';
-      pickBtn.addEventListener('click', async () => {
-        try {
-          const { dialog } = (require('electron') as { remote?: { dialog: ElectronDialog }; dialog?: ElectronDialog }).remote
-            ?? (require('@electron/remote') as { dialog: ElectronDialog });
-          const result = await dialog.showOpenDialog({ properties: ['openDirectory'], defaultPath: this.vaultRoot });
-          if (!result.canceled && result.filePaths[0]) {
-            input.value = result.filePaths[0];
-            this.cwd = result.filePaths[0];
+      pickBtn.addEventListener('click', () => {
+        void (async () => {
+          try {
+            const { dialog } = (require('electron') as { remote?: { dialog: ElectronDialog }; dialog?: ElectronDialog }).remote
+              ?? (require('@electron/remote') as { dialog: ElectronDialog });
+            const result = await dialog.showOpenDialog({ properties: ['openDirectory'], defaultPath: this.vaultRoot });
+            if (!result.canceled && result.filePaths[0]) {
+              input.value = result.filePaths[0];
+              this.cwd = result.filePaths[0];
+            }
+          } catch {
+            // Electron dialog unavailable — user can type the path manually
           }
-        } catch {
-          // Electron dialog unavailable — user can type the path manually
-        }
+        })();
       });
     }
 
@@ -99,7 +101,7 @@ export class PrimeSessionModal extends Modal {
       field.createEl('div', { text: 'System prompt injected at session start. Leave blank for none.', cls: 'bojubot-param-desc' });
       const ta = field.createEl('textarea', {
         cls: 'bojubot-param-textarea',
-        attr: { placeholder: 'e.g. You are reviewing screenplay drafts in this folder. Focus on structure and pacing.' },
+        attr: { placeholder: 'E.g. You are reviewing screenplay drafts in this folder. Focus on structure and pacing.' },
       });
       ta.addEventListener('input', () => { this.initialInstructions = ta.value; });
     }
@@ -111,7 +113,7 @@ export class PrimeSessionModal extends Modal {
       const cb = row.createEl('input', { attr: { type: 'checkbox' } });
       cb.checked = true;
       row.createSpan({ text: 'Include vault context', cls: 'bojubot-param-label bojubot-prime-toggle-label' });
-      field.createEl('div', { text: 'Vault tree, _claude-context.md, and pinned notes. Uncheck for focused sessions.', cls: 'bojubot-param-desc' });
+      field.createEl('div', { text: 'Vault tree, _Claude-context.md, and pinned notes. Uncheck for focused sessions.', cls: 'bojubot-param-desc' });
       cb.addEventListener('change', () => { this.suppressVaultContext = !cb.checked; });
     }
 
@@ -122,10 +124,10 @@ export class PrimeSessionModal extends Modal {
 
       const btnRow = field.createDiv({ cls: 'bojubot-prime-attach-btns' });
 
-      const fileBtn = btnRow.createEl('button', { text: '+ File', cls: 'bojubot-prime-attach-btn', attr: { type: 'button' } });
+      const fileBtn = btnRow.createEl('button', { text: '+ file', cls: 'bojubot-prime-attach-btn', attr: { type: 'button' } });
       fileBtn.addEventListener('click', () => this.pickFile());
 
-      const noteBtn = btnRow.createEl('button', { text: '+ Note', cls: 'bojubot-prime-attach-btn', attr: { type: 'button' } });
+      const noteBtn = btnRow.createEl('button', { text: '+ note', cls: 'bojubot-prime-attach-btn', attr: { type: 'button' } });
       noteBtn.addEventListener('click', () => this.pickNote());
 
       const urlBtn = btnRow.createEl('button', { text: '+ URL', cls: 'bojubot-prime-attach-btn', attr: { type: 'button' } });
@@ -201,7 +203,7 @@ export class PrimeSessionModal extends Modal {
     const row = container.createDiv({ cls: 'bojubot-prime-url-row' });
     const input = row.createEl('input', {
       cls: 'bojubot-param-input',
-      attr: { type: 'text', placeholder: 'https://…' },
+      attr: { type: 'text', placeholder: 'HTTPS://…' },
     });
     const addBtn = row.createEl('button', { text: 'Add', cls: 'mod-cta', attr: { type: 'button' } });
     const addUrl = () => {

--- a/src/utils/electronUtils.ts
+++ b/src/utils/electronUtils.ts
@@ -1,0 +1,48 @@
+// Electron APIs are not available as static ES imports in the Obsidian plugin
+// build environment — runtime require() is the only supported access pattern.
+
+/* eslint-disable @typescript-eslint/no-require-imports -- Electron runtime access */
+
+interface ElectronDialogResult {
+  canceled: boolean;
+  filePaths: string[];
+}
+
+export interface ElectronDialog {
+  showOpenDialog(opts: {
+    properties: string[];
+    defaultPath?: string;
+  }): Promise<ElectronDialogResult>;
+}
+
+interface ElectronClipboard {
+  readFilePaths(): string[];
+}
+
+/** Returns the Electron dialog API, or null if unavailable (non-desktop context). */
+export function getElectronDialog(): ElectronDialog | null {
+  try {
+    const electron = require('electron') as {
+      remote?: { dialog: ElectronDialog };
+      dialog?: ElectronDialog;
+    };
+    if (electron.dialog) return electron.dialog;
+    if (electron.remote?.dialog) return electron.remote.dialog;
+    const remote = require('@electron/remote') as { dialog: ElectronDialog };
+    return remote.dialog ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Returns the Electron clipboard API, or null if unavailable. */
+export function getElectronClipboard(): ElectronClipboard | null {
+  try {
+    const { clipboard } = require('electron') as { clipboard: ElectronClipboard };
+    return clipboard ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/* eslint-enable @typescript-eslint/no-require-imports */


### PR DESCRIPTION
## Description

Catches lint violations that slipped into 3.3.0. Split across two commits.

Fixes #258, #259. Partially addresses #255 (CI gate still needed).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

**Commit 1 — prime session lint fixes (already in 3.3.0, addressed here for tracking):**
- `no-misused-promises`: `ModelPickerModal` callback (`ClaudeView.ts`) and folder-browse handler (`PrimeSessionModal.ts`)
- `obsidianmd/hardcoded-config-path`: eslint-disable with explanation on instructional string in `ContextManager.ts`
- `obsidianmd/ui/sentence-case`: 7 UI strings auto-fixed in `PrimeSessionModal.ts`

**Commit 2 — Obsidian community bot warnings (#258, #259):**
- `window.setTimeout` / `window.requestAnimationFrame`: replaced bare globals across `AtMentionController`, `ClaudeView`, `ContextGenerationModal`, `ExportToVaultModal`, `PermissionPickerModal`, `PrimeSessionModal`, `SlashMenu`, `UIBridge`
- `activeDocument` instead of `document`: `AttachmentHandler`, `ClaudeView`, `PermissionPickerModal`, `PrimeSessionModal`, `SlashMenu`, `TokenGauge`
- `require()` imports: extracted into `src/utils/electronUtils.ts` (`getElectronDialog`, `getElectronClipboard`) — single justified eslint-disable block replacing inline require calls in `AttachmentHandler` and `PrimeSessionModal`

## How Has This Been Tested?

These are code quality / lint fixes. The window-scoped globals and `activeDocument` changes are functionally identical in the standard (non-popout) window that BojuBot runs in — no behaviour change is expected under normal use.

**If you want to spot-check:**
- [ ] Attach a file via the paperclip button — `activeDocument.createElement` in `AttachmentHandler` and `PrimeSessionModal`
- [ ] Shift+click + and use the folder-browse button — `getElectronDialog()` in `PrimeSessionModal`
- [ ] Paste a file copied from Explorer into the chat — `getElectronClipboard()` in `AttachmentHandler`
- [ ] Open the permission mode picker — `activeDocument` in `PermissionPickerModal`
- [ ] Type @ to trigger note mention — `window.setTimeout` in `AtMentionController`

**Test Configuration:**
- OS: Windows 11
- Version: 3.3.0 + this branch

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published

## Additional Notes

The remaining community bot warnings (#256 `no-unsupported-api`, #257 sentence-case disables, #260 innerHTML/no-unsafe, #261 deprecated APIs) are pre-existing across the broader codebase and will be tackled in a follow-up branch.