### PR TITLE
[chore] Switch to obsidianmd recommended lint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,14 @@ export default [
   // Full community-bot ruleset — stays in sync with Obsidian plugin submission checks
   ...obsidianmd.configs.recommended,
 
+  // Project-specific rule overrides
+  {
+    files: ['**/*.ts'],
+    rules: {
+      'obsidianmd/ui/sentence-case': ['error', { brands: ['BojuBot', 'Claude', 'Obsidian'] }],
+    },
+  },
+
   // Override: add tsconfig project so type-aware rules (@typescript-eslint/no-unsafe-*,
   // no-floating-promises, no-deprecated, etc.) can resolve types
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,16 @@
 import obsidianmd from './node_modules/eslint-plugin-obsidianmd/dist/lib/index.js';
 import tsparser from '@typescript-eslint/parser';
-import tseslint from '@typescript-eslint/eslint-plugin';
 
 export default [
+  { ignores: ['**/*.js'] },
+
+  // Full community-bot ruleset — stays in sync with Obsidian plugin submission checks
+  ...obsidianmd.configs.recommended,
+
+  // Override: add tsconfig project so type-aware rules (@typescript-eslint/no-unsafe-*,
+  // no-floating-promises, no-deprecated, etc.) can resolve types
   {
-    ignores: ['**/*.js'],
-  },
-  {
-    plugins: {
-      obsidianmd,
-      '@typescript-eslint': tseslint,
-    },
+    files: ['**/*.ts'],
     languageOptions: {
       parser: tsparser,
       parserOptions: {
@@ -18,26 +18,5 @@ export default [
         tsconfigRootDir: import.meta.dirname,
       },
     },
-    rules: {
-      // Obsidian plugin rules (matching obsidianmd bot ruleset)
-      'obsidianmd/ui/sentence-case': ['error', { allowAutoFix: true }],
-      'obsidianmd/hardcoded-config-path': 'error',
-      'obsidianmd/commands/no-plugin-id-in-command-id': 'error',
-      'obsidianmd/commands/no-plugin-name-in-command-name': 'error',
-      'obsidianmd/detach-leaves': 'error',
-      'obsidianmd/no-tfile-tfolder-cast': 'error',
-      'obsidianmd/no-static-styles-assignment': 'error',
-      'obsidianmd/settings-tab/no-manual-html-headings': 'error',
-      'obsidianmd/no-forbidden-elements': 'error',
-
-      // TypeScript rules (type-aware — require parserOptions.project)
-      '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/no-floating-promises': 'error',
-      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-      '@typescript-eslint/no-misused-promises': 'error',
-      '@typescript-eslint/require-await': 'error',
-      '@typescript-eslint/no-base-to-string': 'error',
-    },
-    files: ['**/*.ts'],
-  }
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "bojubot",
-  "version": "3.1.1",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bojubot",
-      "version": "3.1.1",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.0.0",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.0",
         "esbuild": "^0.21.0",
+        "eslint-plugin-no-unsanitized": "^4.1.5",
         "eslint-plugin-obsidianmd": "^0.2.4",
         "obsidian": "latest",
         "tslib": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.0",
     "esbuild": "^0.21.0",
+    "eslint-plugin-no-unsanitized": "^4.1.5",
     "eslint-plugin-obsidianmd": "^0.2.4",
     "obsidian": "latest",
     "tslib": "^2.6.0",


### PR DESCRIPTION
## Description

Replaces the hand-picked rule subset in `eslint.config.mjs` with the full `recommended` preset from `eslint-plugin-obsidianmd`, aligning local lint with the Obsidian community plugin submission bot. Adds `BojuBot`, `Claude`, and `Obsidian` to the sentence-case brands allowlist.

Closes #255 (partially — CI workflow still needed as a follow-up).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)

## Changes

- `eslint.config.mjs`: replaced manual rule list with `...obsidianmd.configs.recommended` spread + `tsconfig` project override for type-aware rules
- Added `eslint-plugin-no-unsanitized` (only missing peer dependency)
- Brand names `BojuBot`, `Claude`, `Obsidian` added to `sentence-case` allowlist so UI strings preserve correct capitalisation
- `package.json` / `package-lock.json` updated

Running `npm run lint` now surfaces the same errors the community bot catches. All remaining violations are tracked in open issues (#256–#261) and are pre-existing — no new violations introduced.

## How Has This Been Tested?

- [ ] Run `npm run lint` — expect errors only from open backlog issues (#256 `no-unsupported-api`, #258 `activeWindow`, #260 `innerHTML`/`no-unsafe-*`, #261 `noticeEl`)
- [ ] Run `npm run build` — expect clean output

**Test Configuration:**
- OS: Windows 11
- Version: 3.3.0 + this branch

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Also note: the `window.setTimeout` / `window.requestAnimationFrame` fixes from the previous PR (#254) are flagged by the now-active `prefer-active-doc` rule — the correct global is `activeWindow`, not `window`. This will be corrected as part of #258.