### PR TITLE
[BUG] fix: raise minAppVersion to 1.7.2 to match actual API usage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "bojubot",
   "name": "BojuBot",
   "version": "3.3.0",
-  "minAppVersion": "1.4.0",
+  "minAppVersion": "1.7.2",
   "description": "Claude Code chat panel, skills, and vault-aware AI — fully integrated and native to your vault.",
   "author": "Scott Kirvan",
   "authorUrl": "https://github.com/ScottKirvan",


### PR DESCRIPTION
## Description

Closes #256.

`manifest.json` declared `minAppVersion: 1.4.0` but the codebase uses APIs that require higher versions:

| API | Required version |
|---|---|
| `Vault.getFileByPath` | 1.5.7 |
| `Vault.getAllFolders` | 1.6.6 |
| `AbstractInputSuggest` / `setValue` | 1.4.10 |
| `Workspace.revealLeaf` | 1.7.2 |

Bumping to `1.7.2` (the highest required) clears all `obsidianmd/no-unsupported-api` lint errors. This is conservative relative to the installed Obsidian types (`1.12.3`). BojuBot is desktop-only and requires Claude Code, so users are expected to keep Obsidian reasonably current.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Run `npm run lint` — no `obsidianmd/no-unsupported-api` errors
- [ ] Run `npm run build` — clean output
- [ ] Run the Obsidian community plugin pre-review automation against this branch

**Test Configuration:**
- OS: Windows 11
- Version: 3.3.0 + this branch

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

`revealLeaf` was introduced post-acceptance (commit `f043199`, May 2026). The other APIs were present at time of community plugin submission — the bot likely didn't enforce this rule strictly at that point.