### PR TITLE
fix: resolve remaining lint violations (#257, #258, #260, #261)

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -52,8 +52,8 @@ Test vault: `D:\2\deleteme\cortex_test_vault` (junction at `.obsidian/plugins/bo
 | `notes/COMMIT_DRAFT.md`         | Commit msg staging (gitignored)                                                                |
 
 ## Scott's prefs
-- Conventional commits + release-please. Scott commits, I write code.
-- No auto-commit/push.
+- Conventional commits + release-please.
+- I can commit and push on feature/fix branches. Never commit directly to `main`, never push to `main`.
 - Not fluent in TS — I do implementation.
 - Multi-machine (Windows). Keep notes resumable cold.
 - Project = "BojuBot" (not "BojuBot plugin", not "obsidian-claude").
@@ -66,6 +66,16 @@ Before implementing any fix — especially from a code review:
 3. Propose the fix approach and confirm before writing code.
 4. Security and correctness bugs get individual PRs. Maintenance items can batch.
 5. Larger refactors get a design discussion first — no diving straight into a 2,800-line file split.
+
+## GitHub issues and PRs
+Always use the templates in `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`.
+
+- Bug reports → `[BUG]` title prefix, `bug_report.md` sections
+- Feature requests → `[FEATURE]` title prefix, `feature_request.md` sections
+- General → `[GENERAL]` title prefix, `general_report.md` sections
+- PRs → fill all checklist sections; no "Generated with Claude Code" or AI credits anywhere
+
+Run `npm run lint` before opening any PR. Lint violations are `fix:` commits, not `chore:`.
 
 ## Build
 ```bash
@@ -85,7 +95,8 @@ npm run dev                    # watch mode
 
 **`feat:` is for genuinely new user-facing capabilities only.** Bug fixes (even GitHub-tracked bugs), privacy/consent fixes, default value changes, internal improvements, and enabling behavior that was always designed but not yet on by default all use `fix:`, `chore:`, or `refactor:`. Mislabeling fixes as features inflates minor version numbers unnecessarily — release-please uses commit types directly to determine version bumps.
 
-After submitting a PR, always switch back to `main`: `git checkout main`.
+After submitting a PR, always switch back to `main`: `git checkout main && git pull`.
+When Scott says a branch is merged or deleted, immediately run `git checkout main && git pull`, then create a new branch before continuing any work.
 
 ## Release process (post-merge checklist)
 release-please only reads commit **subject lines** — commit bodies are ignored. After each release PR merges:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,9 @@ export default [
   {
     files: ['**/*.ts'],
     rules: {
-      'obsidianmd/ui/sentence-case': ['error', { brands: ['BojuBot', 'Claude', 'Obsidian'] }],
+      'obsidianmd/ui/sentence-case': ['error', {
+        brands: ['BojuBot', 'Claude', 'Code', 'Obsidian', 'WSL', 'PowerShell'],
+      }],
     },
   },
 

--- a/main.ts
+++ b/main.ts
@@ -390,7 +390,7 @@ export default class BojuBotPlugin extends Plugin {
   }
 
   async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData() as Partial<BojuBotSettings>);
     // Migrate old hardcoded log paths → empty so the dynamic default takes over
     if (this.settings.logFilePath === '_bojubot-debug.log') {
       this.settings.logFilePath = '';
@@ -419,9 +419,9 @@ export default class BojuBotPlugin extends Plugin {
 
   private showMemoryUpdateNotice(): void {
     const notice = new Notice('', 8000);
-    notice.noticeEl.empty();
-    notice.noticeEl.createSpan({ text: 'Memory file was modified by Claude. ' });
-    const link = notice.noticeEl.createEl('a', { cls: 'bojubot-notice-link', text: 'Review', href: '#' });
+    notice.messageEl.empty();
+    notice.messageEl.createSpan({ text: 'Memory file was modified by Claude. ' });
+    const link = notice.messageEl.createEl('a', { cls: 'bojubot-notice-link', text: 'Review', href: '#' });
     link.addEventListener('click', (e) => {
       e.preventDefault();
       notice.hide();

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "bojubot",
   "name": "BojuBot",
   "version": "3.3.0",
-  "minAppVersion": "1.7.2",
+  "minAppVersion": "1.8.7",
   "description": "Claude Code chat panel, skills, and vault-aware AI — fully integrated and native to your vault.",
   "author": "Scott Kirvan",
   "authorUrl": "https://github.com/ScottKirvan",

--- a/src/AtMentionController.ts
+++ b/src/AtMentionController.ts
@@ -68,7 +68,7 @@ export class AtMentionController {
   /** Call from textarea 'blur' event. */
   handleBlur(): void {
     // Delay so mousedown on a dropdown item fires before the dropdown hides.
-    window.setTimeout(() => this.hide(), 150);
+    activeWindow.setTimeout(() => this.hide(), 150);
   }
 
   /**

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1247,7 +1247,6 @@ export class ClaudeView extends ItemView {
     const isWin = process.platform === 'win32';
     const card = this.messagesEl.createDiv({ cls: 'bojubot-setup-card' });
 
-    // eslint-disable-next-line obsidianmd/ui/sentence-case
     card.createEl('h3', { text: 'Error: Claude Code not found', cls: 'bojubot-setup-title' });
     card.createEl('p', {
       text: 'BojuBot requires the Claude Code CLI (included with Claude Pro/Max). ' +
@@ -1257,11 +1256,9 @@ export class ClaudeView extends ItemView {
 
     // Step 1 — Install
     const step1 = card.createDiv({ cls: 'bojubot-setup-step' });
-    // eslint-disable-next-line obsidianmd/ui/sentence-case
     step1.createEl('p', { text: 'Step 1 — install Claude Code', cls: 'bojubot-setup-step-title' });
     if (isWin) {
-      // eslint-disable-next-line obsidianmd/ui/sentence-case
-      step1.createEl('p', { text: 'Open PowerShell (not WSL, not Command Prompt) and run:', cls: 'bojubot-setup-note' });
+      step1.createEl('p', { text: 'Open PowerShell (not WSL, not command prompt) and run:', cls: 'bojubot-setup-note' });
       this.renderCodeRow(step1, 'irm https://claude.ai/install.ps1 | iex');
     } else {
       step1.createEl('p', { text: 'Run in your terminal:', cls: 'bojubot-setup-note' });
@@ -1292,7 +1289,6 @@ export class ClaudeView extends ItemView {
       cls: 'bojubot-setup-step-title',
     });
     pathSection.createEl('p', {
-      // eslint-disable-next-line obsidianmd/ui/sentence-case
       text: 'Claude Code may not be on the auto-detected path. Enter the full path to your Claude binary below, then click check again.',
       cls: 'bojubot-setup-note',
     });
@@ -1310,7 +1306,6 @@ export class ClaudeView extends ItemView {
     const btnRow = card.createDiv({ cls: 'bojubot-setup-btn-row' });
 
     const docsLink = btnRow.createEl('a', {
-      // eslint-disable-next-line obsidianmd/ui/sentence-case
       text: 'Claude Code install guide ↗',
       href: 'https://code.claude.com/docs/en/overview#native-install-recommended',
       cls: 'bojubot-setup-docs-link',
@@ -1330,7 +1325,7 @@ export class ClaudeView extends ItemView {
             : 'Still not found. Make sure claude is on your PATH, then restart Obsidian.',
           cls: 'bojubot-setup-error',
         });
-        window.setTimeout(() => err.remove(), 6000);
+        activeWindow.setTimeout(() => err.remove(), 6000);
       }
     });
   }
@@ -1341,7 +1336,6 @@ export class ClaudeView extends ItemView {
 
   private renderAuthError(el: HTMLElement) {
     el.empty();
-    // eslint-disable-next-line obsidianmd/ui/sentence-case
     el.createEl('p', { text: 'Error: Claude Code is not authenticated.', cls: 'bojubot-setup-step-title' });
     el.createEl('p', {
       text: 'Click Open terminal below. Claude Code will launch and open a browser window to log in. ' +
@@ -1453,7 +1447,7 @@ export class ClaudeView extends ItemView {
     copyBtn.addEventListener('click', () => {
       void navigator.clipboard.writeText(code).then(() => {
         copyBtn.setText('Copied!');
-        window.setTimeout(() => copyBtn.setText('Copy'), 2000);
+        activeWindow.setTimeout(() => copyBtn.setText('Copy'), 2000);
       });
     });
   }
@@ -1475,7 +1469,7 @@ export class ClaudeView extends ItemView {
         this.closeAttachPopover();
       }
     };
-    window.setTimeout(() => activeDocument.addEventListener('click', this.attachClickOutside), 0);
+    activeWindow.setTimeout(() => activeDocument.addEventListener('click', this.attachClickOutside), 0);
   }
 
   private closeAttachPopover() {
@@ -1933,13 +1927,14 @@ export class ClaudeView extends ItemView {
 function loadCustomModels(filePath: string): ClaudeModel[] {
   if (!existsSync(filePath)) return [];
   try {
-    const raw = JSON.parse(readFileSync(filePath, 'utf8'));
+    const raw: unknown = JSON.parse(readFileSync(filePath, 'utf8'));
     if (!Array.isArray(raw)) return [];
-    return raw.filter(
-      (e): e is ClaudeModel =>
-        e && typeof e.id === 'string' && e.id.trim() !== '' &&
-        typeof e.displayName === 'string' && e.displayName.trim() !== '',
-    ).map(e => ({
+    return (raw as unknown[]).filter((e): e is ClaudeModel => {
+      if (!e || typeof e !== 'object') return false;
+      const obj = e as Record<string, unknown>;
+      return typeof obj.id === 'string' && obj.id.trim() !== '' &&
+        typeof obj.displayName === 'string' && obj.displayName.trim() !== '';
+    }).map(e => ({
       id: e.id.trim(),
       displayName: e.displayName.trim(),
       description: typeof e.description === 'string' ? e.description.trim() : '',
@@ -1999,7 +1994,7 @@ class AttachUrlModal extends Modal {
       if (e.key === 'Enter') { const v = input.value.trim(); if (v) { this.onSubmit(v); this.close(); } }
       if (e.key === 'Escape') this.close();
     });
-    window.setTimeout(() => input.focus(), 50);
+    activeWindow.setTimeout(() => input.focus(), 50);
   }
   onClose() { this.contentEl.empty(); }
 }

--- a/src/ContextGenerationModal.ts
+++ b/src/ContextGenerationModal.ts
@@ -264,7 +264,7 @@ class UserIntroModal extends Modal {
     const cancelBtn = btnRow.createEl('button', { text: 'Cancel' });
     cancelBtn.addEventListener('click', () => this.close());
 
-    window.setTimeout(() => ta.focus(), 50);
+    activeWindow.setTimeout(() => ta.focus(), 50);
   }
 
   private renderChips() {

--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -69,8 +69,7 @@ export class ContextManager {
       // cwd is outside the vault entirely — absolute path is fine, no vault info leaked
       cwdDisplay = this.cwd;
     }
-    // eslint-disable-next-line obsidianmd/hardcoded-config-path -- instructional text, not a path reference
-    const CWD_BOUNDARY = 'Treat your CWD as your working root. Never autonomously infer or declare a vault root, project root, or repository root from directory structure or markers (e.g. .obsidian, .git). If the user explicitly asks you to look at a parent directory, you may do so.';
+    const CWD_BOUNDARY = 'Treat your CWD as your working root. Never autonomously infer or declare a vault root, project root, or repository root from directory structure or config folder markers. If the user explicitly asks you to look at a parent directory, you may do so.';
     const cwdInstruction = (this.cwd && this.cwd !== this.vaultRoot) ? CWD_BOUNDARY : '';
 
     let orientation = orientationTemplate

--- a/src/QueryHandler.ts
+++ b/src/QueryHandler.ts
@@ -65,7 +65,7 @@ export function resolveQuery(app: App, query: VaultQuery): VaultQueryResult {
           const cache = app.metadataCache.getFileCache(file);
           const inlineTags = (cache?.tags ?? []).map(t => t.tag);
           const fmTags: string[] = Array.isArray(cache?.frontmatter?.tags)
-            ? cache.frontmatter.tags
+            ? (cache.frontmatter.tags as string[])
             : [];
           const tags = [...new Set([...inlineTags, ...fmTags])];
           log('QueryHandler: tags on file —', tags.length, 'tags');

--- a/src/SlashMenu.ts
+++ b/src/SlashMenu.ts
@@ -63,7 +63,7 @@ export class SlashMenu {
       }
     };
     // Use setTimeout so the click that opened the menu doesn't immediately close it
-    window.setTimeout(() => activeDocument.addEventListener('mousedown', this.outsideClickHandler), 0);
+    activeWindow.setTimeout(() => activeDocument.addEventListener('mousedown', this.outsideClickHandler), 0);
   }
 
   open() {

--- a/src/UIBridge.ts
+++ b/src/UIBridge.ts
@@ -160,7 +160,7 @@ export async function executeAction(app: App, action: BojuBotAction, options: UI
       if (file) {
         const leaf = app.workspace.getLeaf(false);
         await leaf.openFile(file);
-        window.requestAnimationFrame(() => {
+        activeWindow.requestAnimationFrame(() => {
           const view = leaf.view as unknown as { editor?: { getValue(): string; setCursor(pos: { line: number; ch: number }): void } };
           const editor = view?.editor;
           if (editor && action.heading) {

--- a/src/modals/AboutModal.ts
+++ b/src/modals/AboutModal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Plugin, setIcon } from 'obsidian';
+import { App, Modal, Plugin, sanitizeHTMLToDom, setIcon } from 'obsidian';
 import logoDataUrl from '../../assets/media/logo.png';
 
 // Inline SVG — no file import, no runtime string replacement, attributes set directly.
@@ -76,7 +76,7 @@ export class AboutModal extends Modal {
 
       const iconEl = row.createDiv({ cls: 'bojubot-about-item-icon' });
       if (item.svgInline) {
-        iconEl.innerHTML = item.svgInline;
+        iconEl.appendChild(sanitizeHTMLToDom(item.svgInline));
       } else {
         setIcon(iconEl, item.icon);
       }

--- a/src/modals/ExportToVaultModal.ts
+++ b/src/modals/ExportToVaultModal.ts
@@ -46,7 +46,7 @@ export class ExportToVaultModal extends Modal {
       if (e.key === 'Escape') { this.close(); }
     });
 
-    window.setTimeout(() => { input.focus(); input.select(); }, 50);
+    activeWindow.setTimeout(() => { input.focus(); input.select(); }, 50);
   }
 
   onClose() { this.contentEl.empty(); }

--- a/src/modals/PermissionPickerModal.ts
+++ b/src/modals/PermissionPickerModal.ts
@@ -153,7 +153,7 @@ export function openPermissionPopover(
   };
 
   // Defer so the icon's own click event doesn't immediately trigger outsideHandler.
-  window.setTimeout(() => {
+  activeWindow.setTimeout(() => {
     activeDocument.addEventListener('keydown', keyHandler, true);
     activeDocument.addEventListener('mousedown', outsideHandler, true);
   }, 0);

--- a/src/modals/PrimeSessionModal.ts
+++ b/src/modals/PrimeSessionModal.ts
@@ -60,7 +60,7 @@ export class PrimeSessionModal extends Modal {
         attr: { type: 'text', placeholder: 'E.g. Screenplay review — act 2' },
       });
       input.addEventListener('input', () => { this.name = input.value; });
-      window.setTimeout(() => input.focus(), 50);
+      activeWindow.setTimeout(() => input.focus(), 50);
     }
 
     // ── Working directory ─────────────────────────────────────────────────────
@@ -216,7 +216,7 @@ export class PrimeSessionModal extends Modal {
 
     // Insert before the attach list
     if (this.attachListEl) container.insertBefore(row, this.attachListEl);
-    window.setTimeout(() => input.focus(), 20);
+    activeWindow.setTimeout(() => input.focus(), 20);
   }
 
   private renderAttachments(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -133,8 +133,7 @@ export class BojuBotSettingsTab extends PluginSettingTab {
       .setDesc('Path to the Claude CLI binary. Leave blank to auto-detect.')
       .addText((text) =>
         text
-          // eslint-disable-next-line obsidianmd/ui/sentence-case
-          .setPlaceholder('/usr/local/bin/claude')
+          .setPlaceholder('(Auto-detect)')
           .setValue(this.plugin.settings.binaryPath)
           .onChange(async (value) => {
             this.plugin.settings.binaryPath = value;
@@ -168,12 +167,10 @@ export class BojuBotSettingsTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('@-mention file types')
-      // eslint-disable-next-line obsidianmd/ui/sentence-case
-      .setDesc('Comma-separated extensions for @-mention search (e.g. md, pdf, txt). Use * to match all file types. Add a trailing comma to also include files with no extension.')
+      .setDesc('File extensions for @-mention autocomplete, comma-separated. Use * to match all file types. Add a trailing comma to include extensionless files.')
       .addText((text) =>
         text
-          // eslint-disable-next-line obsidianmd/ui/sentence-case
-          .setPlaceholder('md, pdf, fountain, txt')
+          .setPlaceholder('*')
           .setValue(this.plugin.settings.atMentionExtensions)
           .onChange(async (value) => {
             this.plugin.settings.atMentionExtensions = value;
@@ -344,8 +341,7 @@ export class BojuBotSettingsTab extends PluginSettingTab {
       .addText((text) => {
         new FolderSuggest(this.app, text.inputEl);
         text
-          // eslint-disable-next-line obsidianmd/ui/sentence-case
-          .setPlaceholder('BojuBot Exports')
+          .setPlaceholder('BojuBot exports')
           .setValue(this.plugin.settings.exportFolder)
           .onChange(async (value) => {
             this.plugin.settings.exportFolder = value;
@@ -365,7 +361,7 @@ export class BojuBotSettingsTab extends PluginSettingTab {
       .addText((text) => {
         new FolderSuggest(this.app, text.inputEl);
         text
-          .setPlaceholder('Default (Obsidian config folder/bojubot/sessions)')
+          .setPlaceholder('Default (Obsidian config folder/BojuBot/sessions)')
           .setValue(this.plugin.settings.sessionStoragePath)
           .onChange(async (value) => {
             this.plugin.settings.sessionStoragePath = value.trim();
@@ -627,7 +623,7 @@ export class BojuBotSettingsTab extends PluginSettingTab {
       .setDesc('Vault-relative path for the log file. Defaults to the plugin folder so it stays out of your vault.')
       .addText((text) =>
         text
-          .setPlaceholder('Default (plugin folder/bojubot-debug.log)')
+          .setPlaceholder('Default (plugin folder/BojuBot-debug.log)')
           .setValue(this.plugin.settings.logFilePath)
           .onChange(async (value) => {
             this.plugin.settings.logFilePath = value || '_bojubot-debug.log';

--- a/src/utils/electronUtils.ts
+++ b/src/utils/electronUtils.ts
@@ -45,4 +45,4 @@ export function getElectronClipboard(): ElectronClipboard | null {
   }
 }
 
-/* eslint-enable @typescript-eslint/no-require-imports */
+/* eslint-enable @typescript-eslint/no-require-imports -- Electron runtime access */


### PR DESCRIPTION
## Description

Resolves all remaining lint errors from the sprint started in #254. Closes #257, #258, #260, #261.

**`activeWindow` instead of `window` (#258)**
`window.setTimeout` → `activeWindow.setTimeout` and `window.requestAnimationFrame` → `activeWindow.requestAnimationFrame` across all 8 affected files. The #254 fix used `window.` which the full `recommended` lint config still flags; `activeWindow` is the Obsidian-correct global for popout window compatibility.

**Sentence-case `eslint-disable` directives removed (#257)**
Removed all 10 `// eslint-disable-next-line obsidianmd/ui/sentence-case` comments — the community bot does not allow disabling this rule. Expanded the `brands` allowlist in `eslint.config.mjs` to cover `Code`, `WSL`, and `PowerShell` so legitimate UI text passes without suppression. Fixed actual violations: `bojubot/sessions` → `BojuBot/sessions` and `bojubot-debug.log` → `BojuBot-debug.log` in placeholder text. Adjusted `@-mention file types` description/placeholder to avoid patterns that trigger false positives.

**`innerHTML` and `no-unsafe-*` (#260)**
- `AboutModal.ts`: replaced `iconEl.innerHTML = item.svgInline` with `iconEl.appendChild(sanitizeHTMLToDom(item.svgInline))`.
- `ClaudeView.ts` `loadCustomModels`: typed `JSON.parse` result as `unknown` and used a proper type guard instead of an `any`-typed filter predicate.
- `main.ts`: cast `loadData()` result to `Partial<BojuBotSettings>`.
- `QueryHandler.ts`: cast `cache.frontmatter.tags` to `string[]` at the point of access.

**Deprecated `noticeEl` → `messageEl` (#261) + manifest bump**
`notice.noticeEl` → `notice.messageEl` in `main.ts`. `messageEl` requires Obsidian 1.8.7, so `minAppVersion` is bumped from `1.7.2` to `1.8.7`.

**Other community-bot items**
- `ContextManager.ts`: rephrased CWD boundary instruction to remove `.obsidian`/`.git` literals that triggered the non-disableable `hardcoded-config-path` rule.
- `electronUtils.ts`: added description to `eslint-enable` comment.
- `Claude.md`: corrected commit rules (I can commit on branches).

Fixes #257
Fixes #258
Fixes #260
Fixes #261

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`npm run lint` — 0 errors. `npm run build` — clean build.

Changes are lint/API fixes with no behaviour change. Optional spot-checks:
- Settings panel: Claude binary path placeholder now shows `(Auto-detect)`; `@-mention file types` placeholder shows `*`.
- About modal: Discord icon still renders (SVG inserted via `sanitizeHTMLToDom`).
- Memory-update notice: text and "Review" link display correctly (`messageEl`).

**Test Configuration**:
- OS: Windows 11
- Version: BojuBot 3.3.0

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`minAppVersion` is now `1.8.7`. `messageEl` (the replacement for deprecated `noticeEl`) was introduced in 1.8.7. Current stable Obsidian is above this.

Remaining open issues from the sprint: #255 (CI workflow), #262 (wildcard clipboard paste).