### PR TITLE
fix: catch showOpenDialog rejections in PrimeSessionModal folder picker

### DIFF
--- a/src/modals/PrimeSessionModal.ts
+++ b/src/modals/PrimeSessionModal.ts
@@ -1,8 +1,9 @@
-import { App, FuzzySuggestModal, Modal, TFile, setIcon } from 'obsidian';
+import { App, FuzzySuggestModal, Modal, Notice, TFile, setIcon } from 'obsidian';
 import type { PendingContext } from '../AttachmentHandler';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { getElectronDialog } from '../utils/electronUtils';
+import { log } from '../utils/logger';
 
 export interface PrimeSessionOptions {
   name: string;
@@ -82,10 +83,15 @@ export class PrimeSessionModal extends Modal {
         void (async () => {
           const dialog = getElectronDialog();
           if (!dialog) return;
-          const result = await dialog.showOpenDialog({ properties: ['openDirectory'], defaultPath: this.vaultRoot });
-          if (!result.canceled && result.filePaths[0]) {
-            input.value = result.filePaths[0];
-            this.cwd = result.filePaths[0];
+          try {
+            const result = await dialog.showOpenDialog({ properties: ['openDirectory'], defaultPath: this.vaultRoot });
+            if (!result.canceled && result.filePaths[0]) {
+              input.value = result.filePaths[0];
+              this.cwd = result.filePaths[0];
+            }
+          } catch (err) {
+            log('error', 'showOpenDialog failed', err);
+            new Notice('Could not open folder picker.');
           }
         })();
       });


### PR DESCRIPTION
## Description
Fixes #267

Wraps `showOpenDialog()` in a `try/catch` inside the existing async IIFE so that Electron dialog rejections are caught, logged, and surfaced to the user rather than silently discarded by `void`.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Manual: trigger a dialog failure (e.g. by patching `getElectronDialog` to throw) and confirm the Notice appears and the error appears in `bojubot-debug.log`

**Test Configuration**:
- OS: Windows 11
- Version: 3.3.0

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings