### PR TITLE
fix: handle saveSettings failure on model switch and prevent tmp filename collision

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1837,11 +1837,16 @@ export class ClaudeView extends ItemView {
     const allModels = [...CLAUDE_MODELS, ...loadCustomModels(customModelsPath)];
 
     new ModelPickerModal(this.app, this.plugin.settings.defaultModel, allModels, (model) => {
+      const previous = this.plugin.settings.defaultModel;
       this.plugin.settings.defaultModel = model.id;
       void this.plugin.saveSettings().then(() => {
         this.updateModelIndicator();
         this.appendMessage('system', `Switching to ${model.displayName} — starting new session.`);
         this.startNewSession();
+      }).catch((err: unknown) => {
+        this.plugin.settings.defaultModel = previous;
+        log('error', 'Failed to save model setting', err);
+        new Notice('Failed to save model setting. Please try again.');
       });
     }).open();
   }

--- a/src/modals/PrimeSessionModal.ts
+++ b/src/modals/PrimeSessionModal.ts
@@ -246,7 +246,7 @@ export class PrimeSessionModal extends Modal {
   private saveBinaryToTmp(filename: string, data: ArrayBuffer): string {
     const tmpDir = join(this.vaultRoot, this.configDir, 'plugins', 'bojubot', 'tmp');
     if (!existsSync(tmpDir)) mkdirSync(tmpDir, { recursive: true });
-    const filePath = join(tmpDir, filename);
+    const filePath = join(tmpDir, `${Date.now()}-${filename}`);
     writeFileSync(filePath, Buffer.from(data));
     return filePath;
   }


### PR DESCRIPTION
## Summary
- #268: `saveSettings()` rejection on model switch is now caught — rolls back the in-memory `defaultModel` to its previous value, logs via `log('error', ...)`, and shows a `Notice` to the user. Session restart and indicator update are skipped on failure.
- #269: `saveBinaryToTmp()` in `PrimeSessionModal` now prefixes filenames with `Date.now()-` (e.g. `1719359012345-image.png`) so two attachments with the same base name no longer overwrite each other. Consistent with the paste-event pattern in `AttachmentHandler.ts`.

## Root cause
**#268:** The original `.then()` chain had no `.catch()`, so a rejected promise left `defaultModel` mutated in memory with no persistence and no feedback.

**#269:** Files were written to `<tmp>/<original-filename>` with no uniqueness guarantee. A second file with the same name silently replaced the first, corrupting the first `PendingContext` entry's content.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (89/89)
- [ ] Manual: open PrimeSession (Shift+click +), attach two files with the same name — both should survive in the tmp dir with distinct `Date.now()` prefixes
- [ ] Manual: force a saveSettings failure and switch models — should see a Notice and no session restart
