### PR TITLE
fix: update Discord invite URL to correct server link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 - GitHub Issues: [Report an issue](https://github.com/ScottKirvan/BojuBot/issues)
 - LinkedIn: [linkedin.com/in/scottkirvan/](https://www.linkedin.com/in/scottkirvan/)
-- Discord: [discord.gg/TSKHvVFYxB](https://discord.gg/TSKHvVFYxB)
+- Discord: [discord.gg/TN6XJSNK5Y](https://discord.gg/TN6XJSNK5Y)
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,4 +158,4 @@ CHANGELOG is generated automatically by release-please from commit messages; you
 
 Open an issue, or reach out via:
 - [LinkedIn](https://www.linkedin.com/in/scottkirvan/)
-- [Discord](https://discord.gg/TSKHvVFYxB) — cptvideo
+- [Discord](https://discord.gg/TN6XJSNK5Y) — cptvideo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bojubot",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bojubot",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.0.0",


### PR DESCRIPTION
## Summary
- Updates Discord invite URL from `discord.gg/TSKHvVFYxB` to the correct `discord.gg/TN6XJSNK5Y` across all markdown and workflow files

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
**Steps to verify:**
1. Search this repo for `TSKHvVFYxB` — should return no results
2. Confirm Discord links point to `discord.gg/TN6XJSNK5Y`

**Expected result:** All Discord links use the correct invite URL.

**Test environment:**
- GitHub web UI / text search

## Checklist
- [x] I have performed a self-review of my own code
- [x] No stale Discord invite URLs remain in this repo