### PR TITLE
fix: add emoji input to discord-notify job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,4 +96,5 @@ jobs:
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "BojuBot"
+      emoji: "👾"
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,13 @@ jobs:
         📖 [User Guide](https://www.scottkirvan.com/BojuBot/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/BojuBot/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/BojuBot/issues/new?template=feature_request.md)
     secrets: inherit
 
+  update-changelog-prs:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ScottKirvan/.github/.github/workflows/reusable-update-changelog-prs.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+
   discord-notify:
     needs: [improve-release-notes, build-and-upload]
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
## Summary
- Passes `emoji: "👾"` to `reusable-discord-notify.yml` for BojuBot Discord announcements

## Notes
Depends on [ScottKirvan/.github#8](https://github.com/ScottKirvan/.github/pull/8) being merged first — that PR adds the `emoji` input to the reusable workflow. Merge order: `.github#8` → these three PRs.

## Test plan
- [ ] Merge ScottKirvan/.github#8 first
- [ ] Merge this PR
- [ ] Trigger a release and verify Discord message shows 👾 instead of 🚀