### PR TITLE
feat: add Claude Fable 5 to available model list

### DIFF
--- a/agents/BojuBot_dev/NOTES.md
+++ b/agents/BojuBot_dev/NOTES.md
@@ -1,0 +1,1 @@
+# Dev Agent Notes

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,7 @@ export const CLAUDE_MODELS: ClaudeModel[] = [
   { id: 'claude-haiku-4-5', displayName: 'Claude Haiku 4.5', description: 'Fastest — great for quick tasks' },
   { id: 'claude-sonnet-4-6', displayName: 'Claude Sonnet 4.6', description: 'Balanced speed and capability (default)' },
   { id: 'claude-opus-4-8', displayName: 'Claude Opus 4.8', description: 'Most capable — best for complex reasoning' },
+  { id: 'claude-fable-5', displayName: 'Claude Fable 5', description: 'Most capable — coding-focused, highest reasoning' },
 ];
 
 export interface BojuBotSettings {


### PR DESCRIPTION
## Description

Adds Claude Fable 5 (`claude-fable-5`) to the available model list in `src/settings.ts`. Now selectable from the model picker alongside Haiku 4.5, Sonnet 4.6, and Opus 4.8.

Also includes the dev agent `NOTES.md` file (new tracked file -- collects out-of-scope observations from agentic runs; previous run's notes cleared as non-actionable).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Select Fable 5 in the model picker and confirm sessions spawn with `--model claude-fable-5`

**Test Configuration**:
- OS: Windows 11
- Version: 3.3.2

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes