### PR TITLE
fix: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Allows the release workflow to be triggered manually from the GitHub Actions UI, useful for kicking off release-please after a workflow failure or testing the pipeline without a dummy commit.