### PR TITLE
fix: add release-please to discord-notify needs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
 
   discord-notify:
-    needs: [improve-release-notes, build-and-upload]
+    needs: [release-please, improve-release-notes, build-and-upload]
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ScottKirvan/.github/.github/workflows/reusable-discord-notify.yml@main
     with:


### PR DESCRIPTION
## Summary

- `discord-notify` had `needs: [improve-release-notes, build-and-upload]` — `release-please` was missing
- GitHub only resolves `needs.X.outputs.*` for jobs in the direct `needs` list; with `release-please` absent, `tag_name` resolved to `''`
- Discord embed URL became `https://github.com/ScottKirvan/BojuBot/releases/tag/` → 404

## Test plan

- [ ] After merge, trigger a release and verify the Discord "Downloads" link points to the correct release page