### PR TITLE
fix: block a new turn from starting while one is already running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Before implementing any fix — especially from a code review:
 5. Larger refactors get a design discussion first — no diving straight into a 2,800-line file split.
 
 ## GitHub issues and PRs
-Always use the templates in `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`.
+Templates aren't stored in this repo — they live in the org-wide `ScottKirvan/.github` repo (`.github/ISSUE_TEMPLATE/` and `.github/pull_request_template.md`) and apply automatically to BojuBot via GitHub's community-health-file fallback. Fetch them from there (e.g. `gh api repos/ScottKirvan/.github/contents/...` or the raw URL) if you need the exact section headers.
 
 - Bug reports → `[BUG]` title prefix, `bug_report.md` sections
 - Feature requests → `[FEATURE]` title prefix, `feature_request.md` sections

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -155,10 +155,7 @@ export class ClaudeView extends ItemView {
     this._setupCoordinatorEvents();
     this.tokenGauge = new TokenGauge({
       getSessionId: () => this.coordinator.sessionId,
-      getBinaryPath: () => this.plugin.claudeBinaryPath ?? '',
-      getVaultRoot: () => this.plugin.getVaultRoot(),
-      getEnv: () => this.plugin.shellEnv,
-      getPermissionMode: () => this.coordinator.getEffectivePermissionMode(),
+      compact: (onDone, onError) => this.coordinator.compact(onDone, onError),
     });
     this.attachmentHandler = new AttachmentHandler({
       getVaultRoot: () => this.plugin.getVaultRoot(),

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -1027,6 +1027,11 @@ export class ClaudeView extends ItemView {
     const prompt = this.inputEl.value.trim();
     if (!prompt) return;
 
+    if (this.coordinator.isBusy) {
+      new Notice('BojuBot: a turn is already running — wait for it to finish or press stop first.');
+      return;
+    }
+
     if (!this.plugin.claudeBinaryPath) {
       this.appendMessage('system', 'Claude binary not found. Check BojuBot settings.');
       return;

--- a/src/ContextGenerationModal.ts
+++ b/src/ContextGenerationModal.ts
@@ -1,10 +1,56 @@
 import { App, FuzzySuggestModal, Modal, Notice, TFile } from 'obsidian';
 import type BojuBotPlugin from '../main';
-import { spawnClaude, parseStreamOutput } from './ClaudeProcess';
+import { spawnClaude, parseStreamOutput, killProcess } from './ClaudeProcess';
 import { buildVaultTree } from './utils/fileTree';
 import { log } from './utils/logger';
 import { existsSync, readdirSync } from 'fs';
 import { join, isAbsolute } from 'path';
+
+/**
+ * Blocks the user from starting a chat session while the background context-file
+ * generation is in flight — starting one earlier would race with it (the new
+ * session's context injection would run before the file exists) and was part of
+ * the concurrent-process incident in #287. Not dismissible via Escape/outside-click
+ * while generation is running; only Cancel or completion closes it for real.
+ */
+class ContextGenerationProgressModal extends Modal {
+  private settled = false;
+
+  constructor(app: App, private onCancel: () => void) {
+    super(app);
+  }
+
+  onOpen() {
+    this.titleEl.setText('Generating your context file…');
+    const { contentEl } = this;
+    contentEl.createEl('p', {
+      text: 'Claude is exploring your vault and writing your context file. ' +
+        'The chat isn\'t ready yet — starting a session now would race with this background work.',
+    });
+    const btnRow = contentEl.createDiv({ cls: 'modal-button-container' });
+    const cancelBtn = btnRow.createEl('button', { text: 'Cancel generation', cls: 'mod-warning' });
+    cancelBtn.addEventListener('click', () => {
+      this.settled = true;
+      this.onCancel();
+      this.close();
+    });
+  }
+
+  /** Call when generation finishes (success or error) to allow the modal to actually close. */
+  finish() {
+    this.settled = true;
+    this.close();
+  }
+
+  onClose() {
+    this.contentEl.empty();
+    if (!this.settled) {
+      // Generation is still running and the user tried to dismiss via Escape or
+      // clicking outside — reopen immediately rather than letting them proceed.
+      activeWindow.setTimeout(() => this.open(), 0);
+    }
+  }
+}
 
 export class ContextGenerationModal extends Modal {
   private plugin: BojuBotPlugin;
@@ -93,7 +139,6 @@ export class ContextGenerationModal extends Modal {
   }
 
   private generateContextFile(userIntro: string, contextFiles: string[] = []) {
-    new Notice('BojuBot: generating context file in the background…');
     log('ContextGenerationModal: spawning background generation');
 
     const tree = buildVaultTree(this.app.vault, this.vaultTreeDepth);
@@ -145,6 +190,15 @@ export class ContextGenerationModal extends Modal {
       env: this.env,
     });
 
+    let cancelled = false;
+    const progressModal = new ContextGenerationProgressModal(this.app, () => {
+      log('ContextGenerationModal: generation cancelled by user');
+      cancelled = true;
+      killProcess(proc);
+      new Notice('BojuBot: context file generation cancelled.');
+    });
+    progressModal.open();
+
     parseStreamOutput(proc, {
       onText: () => { /* background — discard streaming text */ },
       onAction: () => { /* background — discard UI actions */ },
@@ -152,6 +206,10 @@ export class ContextGenerationModal extends Modal {
       onPermissionDenied: () => { /* background generation — denials not surfaced */ },
       onUsage: () => { /* background generation — usage not surfaced */ },
       onDone: () => {
+        progressModal.finish();
+        // Killing the process still fires this via the stream's close event —
+        // the cancel callback above already gave the user a notice, don't pile on.
+        if (cancelled) return;
         const exists = this.app.vault.getFileByPath(this.contextFilePath);
         if (exists) {
           new Notice(`BojuBot: context file created at "${this.contextFilePath}". Open it in Obsidian to review and edit.`);
@@ -161,6 +219,7 @@ export class ContextGenerationModal extends Modal {
       },
       onError: (err) => {
         log('ContextGenerationModal: error:', err);
+        if (cancelled) return;
         new Notice('BojuBot: context file generation encountered an error. Check the debug log.');
       },
     });

--- a/src/ContextGenerationModal.ts
+++ b/src/ContextGenerationModal.ts
@@ -1,7 +1,7 @@
 import { App, FuzzySuggestModal, Modal, Notice, TFile } from 'obsidian';
 import type BojuBotPlugin from '../main';
 import { spawnClaude, parseStreamOutput, killProcess } from './ClaudeProcess';
-import { buildVaultTree } from './utils/fileTree';
+import { ContextManager } from './ContextManager';
 import { log } from './utils/logger';
 import { existsSync, readdirSync } from 'fs';
 import { join, isAbsolute } from 'path';
@@ -96,7 +96,7 @@ export class ContextGenerationModal extends Modal {
     generateBtn.addEventListener('click', () => {
       this.close();
       new UserIntroModal(this.app, (intro, contextFiles) => {
-        this.generateContextFile(intro, contextFiles);
+        void this.generateContextFile(intro, contextFiles);
       }).open();
     });
 
@@ -138,13 +138,33 @@ export class ContextGenerationModal extends Modal {
     }
   }
 
-  private generateContextFile(userIntro: string, contextFiles: string[] = []) {
+  private async generateContextFile(userIntro: string, contextFiles: string[] = []) {
     log('ContextGenerationModal: spawning background generation');
 
-    const tree = buildVaultTree(this.app.vault, this.vaultTreeDepth);
-    const treeSection = tree
-      ? `Here is the current vault structure (folder and file names only — no file contents):\n\`\`\`\n${tree}\n\`\`\``
-      : 'The vault structure is not available — please explore with your file tools.';
+    // Reuse the same session-start context injection every normal session gets
+    // (orientation — including the "ignore additional working directories"
+    // boundary — vault tree at the configured depth, pinned notes, per-file
+    // instructions) instead of a separate hand-rolled prompt. Keeps this path in
+    // sync with fixes made to ContextManager instead of silently drifting out of
+    // date, and respects the user's actual settings (tree depth, autonomous
+    // memory, command allowlist) rather than re-deciding them here.
+    // Permission mode is forced to 'standard' regardless of the user's configured
+    // default — generation always needs write access to create the file.
+    const ctx = new ContextManager(
+      this.app,
+      this.contextFilePath,
+      this.plugin.settings.autonomousMemory,
+      this.vaultTreeDepth,
+      this.plugin.settings.commandAllowlist,
+      'standard',
+      this.plugin.settings.contextFileSizeCapTokens,
+      false,
+      false,
+      '',
+      this.vaultRoot,
+      this.vaultRoot,
+    );
+    const sessionContext = await ctx.buildSessionContext();
 
     const skills = this.listSkills();
     const skillsSection = skills.length > 0
@@ -161,10 +181,9 @@ export class ContextGenerationModal extends Modal {
 
     const today = new Date().toISOString().slice(0, 10);
 
-    const prompt = [
+    const instructions = [
       `You are setting up a context file for a new BojuBot (Obsidian plugin) user.`,
       ``,
-      `${treeSection}`,
       `${introSection}`,
       `${contextFilesSection}`,
       `${skillsSection}`,
@@ -183,11 +202,14 @@ export class ContextGenerationModal extends Modal {
       `Write the file now using your file tools. Do not ask for confirmation — just create it.`,
     ].join('\n');
 
+    const prompt = sessionContext ? `${sessionContext}\n\n${instructions}` : instructions;
+
     const proc = spawnClaude({
       binaryPath: this.binaryPath,
       prompt,
       vaultRoot: this.vaultRoot,
       env: this.env,
+      permissionMode: 'standard',
     });
 
     let cancelled = false;

--- a/src/ContextGenerationModal.ts
+++ b/src/ContextGenerationModal.ts
@@ -2,6 +2,7 @@ import { App, FuzzySuggestModal, Modal, Notice, TFile } from 'obsidian';
 import type BojuBotPlugin from '../main';
 import { spawnClaude, parseStreamOutput, killProcess } from './ClaudeProcess';
 import { ContextManager } from './ContextManager';
+import { VIEW_TYPE_CLAUDE } from './ClaudeView';
 import { log } from './utils/logger';
 import { existsSync, readdirSync } from 'fs';
 import { join, isAbsolute } from 'path';
@@ -110,6 +111,17 @@ export class ContextGenerationModal extends Modal {
         'This file gives Claude persistent memory of your vault across sessions. ' +
         'You can have Claude generate one from your vault structure, start with a blank template, or skip for now.',
     });
+
+    // The explicit X button is a deliberate "not now" — unlike an accidental Escape
+    // or outside-click, which reopens this prompt (see onClose()), close the whole
+    // BojuBot panel too instead of leaving it sitting there unconfigured. Attached
+    // with `capture: true` so it runs before Obsidian's own close-button handler —
+    // that handler calls this.close() synchronously, and onClose() needs `settled`
+    // already true by then or it'll reopen this same modal.
+    this.modalEl.querySelector('.modal-close-button')?.addEventListener('click', () => {
+      this.settled = true;
+      this.app.workspace.detachLeavesOfType(VIEW_TYPE_CLAUDE);
+    }, { capture: true });
 
     const btnRow = contentEl.createDiv({ cls: 'modal-button-container' });
 

--- a/src/ContextGenerationModal.ts
+++ b/src/ContextGenerationModal.ts
@@ -15,6 +15,7 @@ import { join, isAbsolute } from 'path';
  */
 class ContextGenerationProgressModal extends Modal {
   private settled = false;
+  private statusEl!: HTMLElement;
 
   constructor(app: App, private onCancel: () => void) {
     super(app);
@@ -24,9 +25,9 @@ class ContextGenerationProgressModal extends Modal {
     this.titleEl.setText('Generating your context file…');
     const { contentEl } = this;
     contentEl.createEl('p', {
-      text: 'Claude is exploring your vault and writing your context file. ' +
-        'The chat isn\'t ready yet — starting a session now would race with this background work.',
+      text: 'Your BojuBot session will start up momentarily, please wait.',
     });
+    this.statusEl = contentEl.createEl('p', { cls: 'bojubot-status', text: 'Thinking…' });
     const btnRow = contentEl.createDiv({ cls: 'modal-button-container' });
     const cancelBtn = btnRow.createEl('button', { text: 'Cancel generation', cls: 'mod-warning' });
     cancelBtn.addEventListener('click', () => {
@@ -34,6 +35,11 @@ class ContextGenerationProgressModal extends Modal {
       this.onCancel();
       this.close();
     });
+  }
+
+  /** Reflect real tool activity so it's obvious the process hasn't hung. */
+  updateStatus(text: string) {
+    this.statusEl?.setText(text);
   }
 
   /** Call when generation finishes (success or error) to allow the modal to actually close. */
@@ -52,6 +58,23 @@ class ContextGenerationProgressModal extends Modal {
   }
 }
 
+/** Friendly status text for the progress modal, based on which tool Claude is using. */
+function statusForTool(tool: string): string {
+  switch (tool) {
+    case 'Read':
+    case 'Glob':
+    case 'Grep':
+      return 'Reading your vault…';
+    case 'Write':
+    case 'Edit':
+      return 'Writing your context file…';
+    case 'ToolSearch':
+      return 'Loading tools…';
+    default:
+      return 'Thinking…';
+  }
+}
+
 export class ContextGenerationModal extends Modal {
   private plugin: BojuBotPlugin;
   private contextFilePath: string;
@@ -59,6 +82,7 @@ export class ContextGenerationModal extends Modal {
   private vaultRoot: string;
   private env: Record<string, string>;
   private vaultTreeDepth: number;
+  private settled = false;
 
   constructor(
     app: App,
@@ -94,6 +118,7 @@ export class ContextGenerationModal extends Modal {
       cls: 'mod-cta',
     });
     generateBtn.addEventListener('click', () => {
+      this.settled = true;
       this.close();
       new UserIntroModal(this.app, (intro, contextFiles) => {
         void this.generateContextFile(intro, contextFiles);
@@ -102,12 +127,14 @@ export class ContextGenerationModal extends Modal {
 
     const blankBtn = btnRow.createEl('button', { text: 'Create blank template' });
     blankBtn.addEventListener('click', () => {
+      this.settled = true;
       this.close();
       void this.createBlankTemplate();
     });
 
     const skipBtn = btnRow.createEl('button', { text: 'Skip' });
     skipBtn.addEventListener('click', () => {
+      this.settled = true;
       this.plugin.settings.skipContextFilePrompt = true;
       void this.plugin.saveSettings().then(() => { this.close(); });
     });
@@ -115,6 +142,17 @@ export class ContextGenerationModal extends Modal {
 
   onClose() {
     this.contentEl.empty();
+    if (!this.settled) {
+      // Easy to fat-finger away via Escape or an outside click before even reading
+      // it — reopen instead of silently losing the offer to set up a context file.
+      activeWindow.setTimeout(() => this.open(), 0);
+    }
+  }
+
+  /** Re-show this same setup prompt — used when the user cancels generation partway through. */
+  reopen(): void {
+    this.settled = false;
+    this.open();
   }
 
   private resolveSkillsFolder(): string {
@@ -218,13 +256,19 @@ export class ContextGenerationModal extends Modal {
       cancelled = true;
       killProcess(proc);
       new Notice('BojuBot: context file generation cancelled.');
+      // Re-show the original setup prompt so the user can choose again
+      // (generate, blank template, or skip) instead of being left with nothing.
+      this.reopen();
     });
     progressModal.open();
 
     parseStreamOutput(proc, {
       onText: () => { /* background — discard streaming text */ },
       onAction: () => { /* background — discard UI actions */ },
-      onToolCall: (tool) => { log('ContextGenerationModal: tool call:', tool); },
+      onToolCall: (tool) => {
+        log('ContextGenerationModal: tool call:', tool);
+        progressModal.updateStatus(statusForTool(tool));
+      },
       onPermissionDenied: () => { /* background generation — denials not surfaced */ },
       onUsage: () => { /* background generation — usage not surfaced */ },
       onDone: () => {

--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -69,8 +69,12 @@ export class ContextManager {
       // cwd is outside the vault entirely — absolute path is fine, no vault info leaked
       cwdDisplay = this.cwd;
     }
+    const ADDITIONAL_DIRS_BOUNDARY = 'Your environment may list "Additional working directories" beyond your CWD — these come from Claude Code CLI\'s own global config and are not something BojuBot set up; they are frequently leftover from unrelated projects. Ignore them: do not read, write, or explore any additional working directory unless the user explicitly directs you there.';
     const CWD_BOUNDARY = 'Treat your CWD as your working root. Never autonomously infer or declare a vault root, project root, or repository root from directory structure or config folder markers. If the user explicitly asks you to look at a parent directory, you may do so.';
-    const cwdInstruction = (this.cwd && this.cwd !== this.vaultRoot) ? CWD_BOUNDARY : '';
+    const cwdInstruction = [
+      ADDITIONAL_DIRS_BOUNDARY,
+      (this.cwd && this.cwd !== this.vaultRoot) ? CWD_BOUNDARY : '',
+    ].filter(Boolean).join(' ');
 
     let orientation = orientationTemplate
       .replace('{{CWD}}', cwdDisplay)

--- a/src/QueryHandler.ts
+++ b/src/QueryHandler.ts
@@ -1,6 +1,7 @@
 import { App, TFolder } from 'obsidian';
 import { log, warn } from './utils/logger';
 import { buildVaultTree } from './utils/fileTree';
+import { neutralizeTriggers } from './constants';
 import uiBridgeRef from './references/ui-bridge.md';
 import vaultQueryRef from './references/vault-query.md';
 import canvasRef from './references/canvas.md';
@@ -157,7 +158,13 @@ export function buildInjectMessage(results: VaultQueryResult[]): string {
       : typeof r.result === 'string'
         ? r.result
         : JSON.stringify(r.result, null, 2);
-    return `Query: ${label}\nResult:\n${body}`;
+    // backlinks/outlinks/tags/file-list results are vault-derived file and folder
+    // names — untrusted content a malicious or planted file could craft to look
+    // like a live @@BOJU line. Neutralize them like every other vault-content
+    // injection path. Help topics return BojuBot's own static reference docs,
+    // which legitimately contain @@BOJU examples, so they're left untouched.
+    const safeBody = r.query.query === 'help' ? body : neutralizeTriggers(body);
+    return `Query: ${label}\nResult:\n${safeBody}`;
   });
   return `[BOJU_VAULT_RESPONSE]\n${parts.join('\n\n')}\n[/BOJU_VAULT_RESPONSE]`;
 }

--- a/src/SessionCoordinator.ts
+++ b/src/SessionCoordinator.ts
@@ -237,6 +237,49 @@ export class SessionCoordinator {
   }
 
   /**
+   * Trigger Claude Code's native /compact slash command via a --resume turn.
+   * Shares the busy guard and _activeProc tracking with send() — previously this
+   * spawned its own untracked process directly from TokenGauge, so compacting
+   * while a turn was streaming raced a second process against the same
+   * --resume session, the same bug class fixed above for send().
+   */
+  compact(onDone: () => void, onError: (message: string) => void): void {
+    if (this._activeProc) {
+      onError('A turn is already in progress — wait for it to finish or cancel it first.');
+      return;
+    }
+    if (!this._sessionId) {
+      onError('No active session to compact.');
+      return;
+    }
+    const binary = this.host.getBinaryPath();
+    if (!binary) {
+      onError('Claude binary not found.');
+      return;
+    }
+
+    let proc: ChildProcess;
+    try {
+      proc = spawnClaude({
+        binaryPath: binary,
+        prompt: '/compact',
+        vaultRoot: this._sessionCwd ?? this.host.getVaultRoot(),
+        env: this.host.getEnv(),
+        resumeSessionId: this._sessionId,
+        permissionMode: this._permissionOverride ?? this.host.getPermissionMode(),
+      });
+    } catch (e) {
+      onError(`Failed to start claude: ${e}`);
+      return;
+    }
+
+    this._activeProc = proc;
+    proc.stdout?.resume();
+    proc.on('close', () => { this._activeProc = null; onDone(); });
+    proc.on('error', (err) => { this._activeProc = null; onError(err.message); });
+  }
+
+  /**
    * Spawn a Claude turn and emit stream events as it runs.
    *
    * @param prompt       Full prompt to send (context already injected by caller).

--- a/src/SessionCoordinator.ts
+++ b/src/SessionCoordinator.ts
@@ -227,6 +227,11 @@ export class SessionCoordinator {
 
   // ── Turn execution ─────────────────────────────────────────────────────────
 
+  /** True while a turn's claude process is running — a second send() must not be started until this clears. */
+  get isBusy(): boolean {
+    return this._activeProc !== null;
+  }
+
   cancel(): void {
     if (this._activeProc) killProcess(this._activeProc);
   }
@@ -239,6 +244,14 @@ export class SessionCoordinator {
    *                        the first turn of a new session. Omit for inject turns.
    */
   send(prompt: string, firstUserInput?: string): void {
+    if (this._activeProc) {
+      // A previous turn's process is still running — starting another here would spawn
+      // a second `claude --resume <id>` against the same session transcript concurrently,
+      // racing both processes' file writes and orphaning the first from cancel().
+      this.emit('turn:error', 'A turn is already in progress — wait for it to finish or cancel it first.');
+      return;
+    }
+
     const binary = this.host.getBinaryPath();
     if (!binary) {
       this.emit('turn:error', 'Claude binary not found.');

--- a/src/SessionCoordinator.ts
+++ b/src/SessionCoordinator.ts
@@ -10,7 +10,7 @@ import {
 } from './ClaudeProcess';
 import { VaultQuery } from './QueryHandler';
 import { BOJU_PREFIX } from './constants';
-import { extractActions, BojuBotAction } from './UIBridge';
+import { extractActions, BojuBotAction } from './utils/actionParser';
 import {
   StoredSession,
   ChatMessage,

--- a/src/TokenGauge.ts
+++ b/src/TokenGauge.ts
@@ -1,12 +1,9 @@
 import { Notice } from 'obsidian';
-import { spawnClaude, PermissionMode } from './ClaudeProcess';
 
 export interface TokenGaugeHost {
   getSessionId(): string | undefined;
-  getBinaryPath(): string;
-  getVaultRoot(): string;
-  getEnv(): Record<string, string>;
-  getPermissionMode(): PermissionMode;
+  /** Delegates to SessionCoordinator.compact() so the reentrancy guard applies. */
+  compact(onDone: () => void, onError: (message: string) => void): void;
 }
 
 /**
@@ -129,16 +126,9 @@ export class TokenGauge {
     this.contextTokens = 0;
     this.update(0);
     new Notice('BojuBot: compacting session…');
-    const proc = spawnClaude({
-      binaryPath: this.host.getBinaryPath(),
-      prompt: '/compact',
-      vaultRoot: this.host.getVaultRoot(),
-      env: this.host.getEnv(),
-      resumeSessionId: sessionId,
-      permissionMode: this.host.getPermissionMode(),
-    });
-    proc.stdout?.resume();
-    proc.on('close', () => new Notice('BojuBot: session compacted.'));
-    proc.on('error', (err) => new Notice(`BojuBot: compaction failed — ${err.message}`));
+    this.host.compact(
+      () => new Notice('BojuBot: session compacted.'),
+      (message) => new Notice(`BojuBot: compaction failed — ${message}`),
+    );
   }
 }

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -23,6 +23,7 @@ import { parseStreamOutput, permissionArgs } from '../src/ClaudeProcess';
 import { extractToolDetail } from '../src/utils/toolFormatting';
 import { extractActions } from '../src/utils/actionParser';
 import { resolveShellEnv } from '../src/utils/shellEnv';
+import { SessionCoordinator, SessionCoordinatorHost } from '../src/SessionCoordinator';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -992,6 +993,64 @@ describe('resolveShellEnv', () => {
     assert.ok('PATH' in env || 'Path' in env, 'PATH must be present');
     for (const v of Object.values(env)) {
       assert.equal(typeof v, 'string', 'no undefined values — process.env entries with undefined must be excluded');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionCoordinator — reentrancy guard
+//
+// Spawns the real Node binary as a stand-in "claude" process (garbage args,
+// exits immediately) purely so a genuine ChildProcess exists to make
+// _activeProc truthy — there's no way to inject a fake spawnClaude today.
+// ---------------------------------------------------------------------------
+
+function makeTestHost(sessionsDir: string): SessionCoordinatorHost {
+  return {
+    getBinaryPath: () => process.execPath,
+    getVaultRoot: () => sessionsDir,
+    getConfigDir: () => '.obsidian',
+    getEnv: () => ({}),
+    getPermissionMode: () => 'standard',
+    getModel: () => '',
+    getSessionsDir: () => sessionsDir,
+    saveLastActiveSessionId: async () => { /* no-op */ },
+    isUiBridgeEnabled: () => false,
+  };
+}
+
+describe('SessionCoordinator reentrancy guard', () => {
+  test('send() rejects a new turn while one is already in flight, and allows one after it clears', async () => {
+    const sessionsDir = mkdtempSync(join(tmpdir(), 'bojubot-coord-test-'));
+    try {
+      const coordinator = new SessionCoordinator(makeTestHost(sessionsDir));
+      const errors: string[] = [];
+      coordinator.on('turn:error', (err) => errors.push(err));
+
+      assert.equal(coordinator.isBusy, false, 'idle before any send()');
+
+      coordinator.send('first prompt');
+      assert.equal(coordinator.isBusy, true, 'busy immediately after send() spawns a process');
+
+      coordinator.send('second prompt — should be rejected');
+      assert.equal(errors.length, 1, 'second send() while busy must be rejected, not spawn a process');
+      assert.match(errors[0], /already in progress/);
+
+      // Wait for the first (real, if short-lived) process to close so onDone clears _activeProc.
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('timed out waiting for turn:done')), 5000);
+        coordinator.on('turn:done', () => { clearTimeout(timer); resolve(); });
+      });
+      assert.equal(coordinator.isBusy, false, 'idle again once the process closes');
+
+      coordinator.send('third prompt — should be accepted now that the coordinator is idle');
+      assert.equal(errors.length, 1, 'no new rejection once the previous turn has cleared');
+      coordinator.cancel();
+      // Give the killed process (and Windows' handle on the tmp dir as its cwd) a moment
+      // to release before cleanup — best-effort either way, this is just a tmp dir.
+      await new Promise(resolve => setTimeout(resolve, 300));
+    } finally {
+      try { rmSync(sessionsDir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
     }
   });
 });


### PR DESCRIPTION
## Summary
Seven fixes, all stemming from an audit triggered by the corrupted-session incident in #287, where a fresh-vault session went off the rails and burned a full token budget in under 5 minutes.

**1. Reentrancy guard on send().** No guard against starting a new Claude turn while a previous one's process was still running. A second send mid-turn (Enter pressed again, a skill autorun, memory audit, or permission-retry flow) spawned a second process against the same `--resume <sessionId>`. Both raced on writes to the same vault files and both appended to the same session transcript, corrupting it — and since `cancel()` only tracked the single latest `_activeProc`, the orphaned earlier process was unreachable by Stop and kept running (and consuming tokens) on its own.

**2. Additional working directories.** Claude read/wrote files in a directory unrelated to the vault, sourced from `permissions.additionalDirectories` in the user's global `~/.claude/settings.json` — a Claude Code CLI setting entirely outside BojuBot's control, often leftover from an unrelated project, merged into every invocation regardless of the `cwd` BojuBot spawns with. The model saw it listed alongside the real vault root and picked the wrong one.

**3. Chat usable during background context generation.** `ContextGenerationModal` ("Generate with Claude" on first run) fired a background `spawnClaude()` and closed its setup modal immediately — the chat panel was usable while that process was still running. Starting a session before the file was written meant that session's one-time context injection (first turn only) would simply skip the file, since it didn't exist yet.

**4. Same reentrancy bug, different button.** Auditing every other `spawnClaude()` call site turned up `TokenGauge.compact()` doing the exact same thing `send()` used to do — spawning its own untracked process directly against the same `--resume` session, bypassing `SessionCoordinator` (and the new guard) entirely. Clicking "Compact" mid-turn would race a second process the same way the original bug did.

**5. Vault-query results skipped the injection-neutralization pass.** Every other vault-content injection path (context file, pinned notes, per-file instructions, attachments) runs untrusted content through `neutralizeTriggers()` before it reaches the model, specifically to stop a maliciously-named file from looking like a live `@@BOJU` protocol line. `QueryHandler.buildInjectMessage()` — which injects backlinks/outlinks/tags/file-list results (real, attacker-plantable vault file and folder names) into an auto-fired `--resume` turn — was missed.

**6. Context-file generation had zero of the orientation fixes.** `ContextGenerationModal` built its own hand-rolled prompt and spawned Claude with no orientation at all, bypassing `ContextManager` entirely — so fix #2 above never applied to it. Confirmed with a live verbose debug log: a fresh generation run explored a stale additional working directory (an unrelated project) as its very first action, before even looking at the actual vault, and then wrote that unrelated project into the generated context file. Same root cause as #287, a second unguarded code path.

**7. Context-generation modals were easy to lose or got stuck without feedback.** The progress modal's copy read as a warning rather than a simple "please wait," gave no indication generation was actually doing anything (vs. hung), and cancelling it left the user with no context file and no further prompt. The original "Set up your context file" modal — the first thing shown on a fresh install — was one accidental Escape/outside-click away from silently losing the offer entirely.

## Changes
- `SessionCoordinator.send()` refuses to spawn while `_activeProc` is set, emitting `turn:error` instead. Added `isBusy` getter as the single source of truth.
- `ClaudeView.handleSend()` checks `coordinator.isBusy` up front and shows a notice — covers every call site (Enter key, skill autorun, memory audit, permission-retry) since they all funnel through `handleSend()`.
- Orientation always tells Claude to treat its CWD as authoritative and ignore any "Additional working directories" listed in its environment unless the user explicitly directs it there.
- `SessionCoordinator` no longer imports through `UIBridge.ts` (which pulls in `obsidian`) — it imports `extractActions`/`BojuBotAction` directly from `utils/actionParser.ts`. This decouples it from the `obsidian` module (types-only, no runtime implementation outside Obsidian), making it importable in the Node unit test runner.
- Added a unit test for the reentrancy guard: spawns a real short-lived child process to make `_activeProc` genuinely truthy, confirms a second `send()` while busy is rejected, and confirms `send()` succeeds again once the first process closes.
- Added `ContextGenerationProgressModal`: opens when background context generation starts, has a Cancel button (kills the process), and reopens itself if dismissed via Escape/outside-click while still running — only Cancel or completion closes it for real.
- Moved `/compact` spawning into `SessionCoordinator.compact()`, sharing `_activeProc` tracking and the busy guard with `send()`. `TokenGauge` no longer touches `ClaudeProcess` directly — it delegates through its host.
- `QueryHandler.buildInjectMessage()` now runs vault-derived result bodies through `neutralizeTriggers()` before injection (help-topic results, which are BojuBot's own static reference docs containing legitimate `@@BOJU` examples, are left untouched).
- `ContextGenerationModal.generateContextFile()` now builds a `ContextManager` the same way a new chat session does — respecting the user's configured vault tree depth, autonomous memory setting, and command allowlist — and prepends its output to the generation-specific instructions, rather than re-deciding orientation content in a separate, divergent implementation. Permission mode is forced to `'standard'` explicitly (generation always needs write access), matching what the injected orientation text now accurately describes.
- Progress-modal copy simplified to "Your BojuBot session will start up momentarily, please wait." Added a status line (reusing the existing `.bojubot-status` blink animation from the chat's "Thinking…" indicator) that updates from real `onToolCall` events — "Reading your vault…", "Writing your context file…", "Loading tools…" — so it's visibly alive rather than just a static message. Cancelling now reopens the original setup modal instead of leaving the user with nothing. The original setup modal itself now uses the same settled-flag/reopen-on-close pattern as the progress modal, so it only closes via one of its three buttons instead of vanishing on a stray click or Escape.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` all pass clean (90 tests, up from 89).
- [x] Fix #6 (context-generation orientation) verified against a live run in a real test vault, with verbose debug logging, before the fix — confirmed the exact failure mode (stale additional-directory exploration, leaked into the generated file).
- [ ] Not yet re-verified in a live vault *after* fix #6 (should no longer explore the stale directory) — worth a follow-up run.
- [ ] Fix #7's modal behavior (reopen-on-cancel, reopen-on-dismiss, live status text) not yet manually clicked through in a live vault.
- [ ] Not independently verified against a live double-send repro, a live additional-directories repro on the main chat path, or the compact-while-busy path — fixes #1 and #4 directly close code paths identified from the corrupted session transcript in #287 (or found while auditing every other injection/spawn site for the same classes of bug), and the reentrancy guard has direct unit coverage, but manual confirmation in a live vault is worth doing before considering this fully closed.

## Related issues
Related to #287 (root cause of the "wrote through a full token budget in minutes" incident)
