### PR TITLE
fix: support live filtering while typing an inline slash command

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -485,7 +485,7 @@ export class ClaudeView extends ItemView {
     });
     this.inputEl.addEventListener('input', () => {
       this.atMentionController.handleInput();
-      this.handleSlashTrigger();
+      this.handleSlashInput();
     });
 
     this.inputEl.addEventListener('blur', () => {
@@ -497,7 +497,9 @@ export class ClaudeView extends ItemView {
       if (this.activeSlashMenu) {
         const consumed = this.activeSlashMenu.handleKeyDown(e);
         if (consumed) return;
-        // Not consumed — menu dismissed itself, let the key fall through normally
+        // Not consumed — an ordinary character (or backspace, etc.); let it
+        // fall through to the textarea, then handleSlashInput() re-derives
+        // the query (or closes the menu) on the resulting 'input' event.
       }
 
       // Dropdown navigation takes priority over everything else
@@ -1743,14 +1745,18 @@ export class ClaudeView extends ItemView {
 
     let commands = this.buildCommands();
 
-    // In inline mode, wrap each action to strip the / trigger before executing
+    // In inline mode, wrap each action to strip the /query run before executing.
+    // Recomputed at execution time (not captured at open time) since the user
+    // may have typed a filter query after the / before selecting a command.
     if (mode === 'inline' && this.inputEl) {
-      const triggerPos = (this.inputEl.selectionStart ?? 1) - 1;
       commands = commands.map(cmd => ({
         ...cmd,
         action: () => {
           const val = this.inputEl.value;
-          this.inputEl.value = val.slice(0, triggerPos) + val.slice(triggerPos + 1);
+          const pos = this.inputEl.selectionStart ?? val.length;
+          const match = val.slice(0, pos).match(/\/(\S*)$/);
+          const start = match ? pos - match[0].length : pos;
+          this.inputEl.value = val.slice(0, start) + val.slice(pos);
           this.inputEl.dispatchEvent(new Event('input'));
           cmd.action();
         },
@@ -1766,8 +1772,27 @@ export class ClaudeView extends ItemView {
     this.activeSlashMenu.open();
   }
 
-  private handleSlashTrigger() {
-    if (this.activeSlashMenu) return;
+  /**
+   * Drives the inline slash menu from the chat input's 'input' event: opens
+   * it when a fresh / is typed at a valid position, re-filters it on every
+   * subsequent keystroke from the live /query text, and closes it once that
+   * text no longer forms a valid query (a space or newline breaks it, same
+   * as the / itself being deleted). Mirrors AtMentionController.handleInput()'s
+   * re-derive-from-scratch approach rather than tracking a stored position.
+   */
+  private handleSlashInput() {
+    if (this.activeSlashMenu) {
+      if (this.activeSlashMenu.mode !== 'inline') return;
+      const { value, selectionStart } = this.inputEl;
+      const pos = selectionStart ?? 0;
+      const match = value.slice(0, pos).match(/\/(\S*)$/);
+      if (!match) {
+        this.activeSlashMenu.close();
+        return;
+      }
+      this.activeSlashMenu.filter(match[1]);
+      return;
+    }
     const { value, selectionStart } = this.inputEl;
     const pos = selectionStart ?? 0;
     // Must have just typed a /

--- a/src/SlashMenu.ts
+++ b/src/SlashMenu.ts
@@ -1,10 +1,14 @@
 /**
  * SlashMenu — unified command palette for BojuBot.
  *
- * Two modes:
- *  - 'button'  opened via the / toolbar button; includes a search box
- *  - 'inline'  opened by typing / in the input; no search box;
- *              any non-navigation key dismisses and is passed back to input
+ * Two modes, both with live filtering as you type:
+ *  - 'button'  opened via the / toolbar button; has its own dedicated search box
+ *  - 'inline'  opened by typing / in the chat input; no search box of its own —
+ *              the chat input itself is the query source. The caller (ClaudeView)
+ *              re-derives the current query from the text after the triggering /
+ *              on every keystroke and calls filter(); it closes the menu once that
+ *              text no longer forms a valid /query run (e.g. a space is typed, or
+ *              the / itself is deleted).
  */
 
 export interface SlashCommand {
@@ -21,7 +25,7 @@ export class SlashMenu {
   private commands: SlashCommand[];
   private filtered: SlashCommand[];
   private highlightedIndex = -1;
-  private mode: 'button' | 'inline';
+  readonly mode: 'button' | 'inline';
   private onDismiss: () => void;
   private outsideClickHandler: (e: MouseEvent) => void;
 
@@ -88,14 +92,19 @@ export class SlashMenu {
         (c.description ?? '').toLowerCase().includes(q)
       )
       : this.commands;
-    this.highlightedIndex = -1;
+    // Auto-highlight the top match once narrowed by a query, so Enter
+    // selects immediately without an extra arrow-down. The full unfiltered
+    // list (empty query) still starts with nothing highlighted.
+    this.highlightedIndex = q && this.filtered.length > 0 ? 0 : -1;
     this.render();
   }
 
   /**
    * Handle keyboard events. Returns true if the key was consumed.
-   * In inline mode, non-navigation keys return false so the caller
-   * can pass them through to the input and dismiss the menu.
+   * Any key not handled below returns false so the caller passes it through
+   * to the input — in inline mode, ClaudeView re-derives the query from the
+   * resulting text on the following 'input' event (see updateSlashMenu());
+   * in button mode, typing simply goes to the dedicated search box.
    */
   handleKeyDown(e: KeyboardEvent): boolean {
     if (e.key === 'Escape') {
@@ -124,12 +133,6 @@ export class SlashMenu {
       }
       return this.mode === 'button';
     }
-    // In inline mode any other key dismisses the menu (caller keeps the key)
-    if (this.mode === 'inline') {
-      this.close();
-      return false;
-    }
-    // In button mode, redirect typing to the search box
     return false;
   }
 


### PR DESCRIPTION
## Summary
Typing `/` in the chat input opens the slash menu, but continued typing to filter the list never worked — any key other than arrows/Enter/Escape dismissed the menu immediately. This has been the behavior since the feature's original implementation; only the toolbar-button-opened menu (which has its own dedicated search box) ever supported live filtering.

## Changes
- `SlashMenu.ts` — inline mode no longer dismisses on ordinary keystrokes; only Escape/arrows/Enter are special-cased. Also auto-highlights the top match once a query narrows the list, so Enter selects immediately without an extra arrow-down first.
- `ClaudeView.ts` — replaced the old "just detect a freshly-typed `/`" trigger with a handler that re-derives the current `/query` from the live input text on every keystroke (mirrors `AtMentionController`'s existing approach for `@`-mentions), closing the menu once the text stops forming a valid query (a space/newline is typed, or the `/` itself gets deleted).
- Also fixes a latent bug the old behavior never exposed: selecting a command used to strip exactly one character at a position captured when the menu first opened. Once typing-to-filter is possible, that would've left stray query text behind in the input. Now recomputes and strips the whole `/query` span at the moment a command is actually selected.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` (112/112) all pass clean.
- [x] Manually verified in a live vault — see steps below.

### Manual test steps
1. In the chat input, type `/` — the menu should open showing all commands.
2. Keep typing, e.g. `/new` — the list should filter live down to matches (e.g. "New session"), with the top match highlighted.
3. Press Enter — the matched command should run, and the input should be left clean (no leftover `/new` text).
4. Repeat, but this time backspace a few characters instead of pressing Enter — the list should widen back out as the query shortens.
5. Backspace all the way past the `/` itself — the menu should close.
6. Type `/` then a space (e.g. `/ `) — the menu should close (space breaks the query).
7. Type `/` then press Escape — menu should close, `/` remains in the input.
8. Regression check: click the toolbar `/` button (button mode) — its dedicated search box should still filter and select exactly as before.
9. Regression check: run a skill via the inline slash menu (e.g. `/` then a skill name) to confirm skill execution still works end to end.