### PR TITLE
chore: match release notes header to manual v3.5.0 edit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,13 @@ jobs:
       project_name: "BojuBot"
       project_context: "BojuBot is an Obsidian plugin. More than a writing assistant — BojuBot turns your Obsidian vault into a personal AI platform using Claude Code."
       header: |
-        ## 👾 BojuBot 👾
+        ## 👾 BojuBot for Obsidian 👾
 
         More than a writing assistant — BojuBot turns your Obsidian vault into a personal AI platform using Claude Code
 
-      footer: |
-        ---
-        🫶❤️[Support this project](https://www.scottkirvan.com/ScottKirvan/sponsor.html) · 📖 [User Guide](https://www.scottkirvan.com/BojuBot/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/BojuBot/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/BojuBot/issues/new?template=feature_request.md) · 📋 [Changelog](https://github.com/ScottKirvan/BojuBot/blob/main/notes/CHANGELOG.md)
+        🫶❤️[Support this project](https://buymeacoffee.com/scottkirvan) · 📖 [User Guide](https://www.scottkirvan.com/BojuBot/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/BojuBot/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/BojuBot/issues/new?template=feature_request.md) · 📋 [Changelog](https://github.com/ScottKirvan/BojuBot/blob/main/notes/CHANGELOG.md)
+
+      changelog_path: ""
     secrets: inherit
 
   update-changelog-prs:

--- a/src/modals/AboutModal.ts
+++ b/src/modals/AboutModal.ts
@@ -2,6 +2,8 @@ import { App, Modal, Plugin, sanitizeHTMLToDom, setIcon } from 'obsidian';
 import logoDataUrl from '../../assets/media/logo.png';
 import { activeBrand, isWhiteLabeled, DEFAULT_BRAND, ResolvedBrand } from '../brand';
 
+const BMAC_URL = 'https://buymeacoffee.com/scottkirvan';
+
 // Inline SVG — no file import, no runtime string replacement, attributes set directly.
 // stroke-width="4" matches Lucide's visual weight at this viewBox size (48×48 vs Lucide's 24×24).
 const DISCORD_SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"
@@ -57,6 +59,17 @@ function buildLinkItems(brand: ResolvedBrand): LinkItem[] {
       desc: 'Source code, issues, and release notes.',
       label: 'View',
       href: links.source,
+    });
+  }
+  // Scott's own funding link, not a brand.links field — never surfaced on a
+  // white-labeled build, same reasoning as the welcome-screen sponsor message.
+  if (!isWhiteLabeled(brand)) {
+    items.push({
+      icon: 'heart',
+      title: 'Buy Me A Coffee',
+      desc: 'Show your love by supporting BojuBot and the author.',
+      label: 'Buy',
+      href: BMAC_URL,
     });
   }
   return items;


### PR DESCRIPTION
## Summary
- Adds "for Obsidian" to the release notes title
- Moves the support/guide/discord/bug/feature/changelog links into the header, above the AI-generated change notes (previously they lived in the footer, after the notes)
- Updates the sponsor link to buymeacoffee.com/scottkirvan
- Disables the separate auto-appended changelog link footer since the changelog link now lives in the header

Matches the manual edit made to the v3.5.0 release notes.

## Test plan
- [ ] Merge and confirm the next release-please release renders header links above the What's New/Bug Fixes sections with no duplicate changelog link