### PR TITLE
chore: point manifest fundingUrl at Buy Me a Coffee

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,6 @@
   "description": "Claude Code chat panel, skills, and vault-aware AI — fully integrated and native to your vault.",
   "author": "Scott Kirvan",
   "authorUrl": "https://github.com/ScottKirvan",
-  "fundingUrl": "https://github.com/sponsors/ScottKirvan",
+  "fundingUrl": "https://buymeacoffee.com/scottkirvan",
   "isDesktopOnly": true
 }


### PR DESCRIPTION
## Summary
- Updates manifest.json's fundingUrl from github.com/sponsors/ScottKirvan to buymeacoffee.com/scottkirvan, matching the About dialog, release notes header, and welcome screen sponsorship message
- README.md's GitHub Sponsors badge is intentionally left as-is (readers following that link are already on GitHub)

## Test plan
- [ ] Merge and confirm Obsidian's community plugin list sponsor icon links to Buy Me a Coffee