### PR TITLE
chore: scale down docs site with global zoom

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,7 @@
+/* VitePress default theme hardcodes most font-size/spacing in px rather
+   than rem, so overriding the root font-size barely affects it. `zoom`
+   rescales the whole rendered page uniformly, the same way browser zoom
+   does, which is what actually shrinks the "too big" feel site-wide. */
+html {
+  zoom: 0.875;
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme'
+import './custom.css'
+
+export default DefaultTheme


### PR DESCRIPTION
## Summary
- Adds a custom theme (docs/.vitepress/theme/) that applies zoom: 0.875 to the whole page
- VitePress's default theme hardcodes font-size/spacing in px rather than rem, so this is the effective way to scale everything (fonts, spacing, nav, sidebar) uniformly, closer to the density of typical professional docs sites

## Test plan
- [ ] Merge and confirm the deployed docs site renders at the smaller scale