### PR TITLE
chore: replace GitHub Sponsors badge with Buy Me A Coffee button

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ BojuBot doesn't stop at the edges of your vault. Given proper permissions (which
 
 BojuBot is free, open source, and built in spare time. If it's useful:
 
-[![GitHub Sponsors](https://img.shields.io/github/sponsors/ScottKirvan?style=social)](https://github.com/sponsors/ScottKirvan)
+**Sponsor BojuBot**
+
+[![Buy Me A Coffee](https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&slug=scottkirvan&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff)](https://buymeacoffee.com/scottkirvan)
 
 ---
 


### PR DESCRIPTION
## Summary
- Swaps the "Support the project" section's GitHub Sponsors badge for a "Sponsor BojuBot" line and a classic yellow Buy Me A Coffee button, linking to buymeacoffee.com/scottkirvan
- Aligns the README with the About dialog, release notes header, welcome screen, and manifest.json's fundingUrl, which already use Buy Me A Coffee

## Test plan
- [ ] Merge and confirm the button renders correctly on GitHub