### PR TITLE
chore: add sponsor section to docs home page

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -5,3 +5,20 @@
 html {
   zoom: 0.875;
 }
+
+/* Tighten the gap between the home page's after-features content
+   (e.g. the sponsor block) and the site footer. VPHome itself carries
+   a 96-128px bottom margin independent of the vp-doc container's own
+   padding, which is the actual source of the large gap. */
+.VPHome .vp-doc.container {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.VPHome {
+  margin-bottom: 24px !important;
+}
+
+.VPFooter {
+  padding-top: 12px !important;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,3 +44,11 @@ features:
     title: No API key needed
     details: BojuBot rides your existing Claude Pro or Max subscription via the Claude Code CLI. No separate billing, no extra configuration.
 ---
+
+<div align="center">
+
+## Sponsor BojuBot
+
+[![Buy Me A Coffee](https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&slug=scottkirvan&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff)](https://buymeacoffee.com/scottkirvan)
+
+</div>


### PR DESCRIPTION
## Summary
- Adds a "Sponsor BojuBot" heading and Buy Me A Coffee button to docs/index.md, rendered below the features grid and above the site footer
- Links to buymeacoffee.com/scottkirvan, matching the sponsor link used elsewhere (About dialog, release notes, welcome screen, manifest.json)
- Tightens VPHome's default 96-128px bottom margin, which otherwise left a large gap between the new content and the footer

## Test plan
- [x] Verified locally with `vitepress build` + preview — button renders correctly and spacing is tight