### PR TITLE
chore: switch funding to Ko-Fi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-github: ScottKirvan
-buy_me_a_coffee: scottkirvan
-patreon: scottkirvan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
         More than a writing assistant — BojuBot turns your Obsidian vault into a personal AI platform using Claude Code
 
-        🫶❤️[Support this project](https://ko-fi.com/scottkirvan) · 📖 [User Guide](https://www.scottkirvan.com/BojuBot/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/BojuBot/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/BojuBot/issues/new?template=feature_request.md) · 📋 [Changelog](https://github.com/ScottKirvan/BojuBot/blob/main/notes/CHANGELOG.md)
+        🫶❤️[Support this project](https://ko-fi.com/ScottKirvan) · 📖 [User Guide](https://www.scottkirvan.com/BojuBot/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/BojuBot/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/BojuBot/issues/new?template=feature_request.md) · 📋 [Changelog](https://github.com/ScottKirvan/BojuBot/blob/main/notes/CHANGELOG.md)
 
       changelog_path: ""
     secrets: inherit

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,9 @@
   "description": "Claude Code chat panel, skills, and vault-aware AI — fully integrated and native to your vault.",
   "author": "Scott Kirvan",
   "authorUrl": "https://github.com/ScottKirvan",
-  "fundingUrl": "https://ko-fi.com/scottkirvan",
+  "fundingUrl": {
+    "GitHub Sponsors": "https://github.com/sponsors/ScottKirvan",
+    "Ko-Fi": "https://ko-fi.com/ScottKirvan"
+  },
   "isDesktopOnly": true
 }


### PR DESCRIPTION
## Summary
- Deletes per-repo `FUNDING.yml` — central `ScottKirvan/.github` FUNDING.yml now applies
- Updates `manifest.json` `fundingUrl` from BMAC to Ko-Fi (object format, keeps GitHub Sponsors)
- Updates hardcoded BMAC link in `release.yml` header to Ko-Fi

## Type of Change
- [x] CI / tooling / workflow change