### PR TITLE
fix: enforce standard mode's Bash restriction via --disallowedTools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ BojuBot is not limited to features that involve Claude Code directly. Obsidian-n
 - `proc.stdin.end()` closes stdin so claude doesn't hang waiting for more input
 - Flags: `--output-format stream-json --verbose --print` + permission-mode args (see below)
 - Permission modes map to CLI args via `permissionArgs()` in `ClaudeProcess.ts`:
-  - **Standard** (default): `--permission-mode acceptEdits`
+  - **Standard** (default): `--permission-mode acceptEdits --disallowedTools Bash`
   - **Read-only**: `--permission-mode default --allowedTools Read,Glob,Grep,WebFetch,WebSearch`
   - **Full**: `--permission-mode bypassPermissions`
   - **Restricted** (planned #154): `--permission-mode default --allowedTools Write,WebFetch,WebSearch` + vault tree injection suppressed

--- a/src/ClaudeProcess.ts
+++ b/src/ClaudeProcess.ts
@@ -29,7 +29,7 @@ export function permissionArgs(mode: PermissionMode): string[] {
       return ['--permission-mode', 'bypassPermissions'];
     case 'standard':
     default:
-      return ['--permission-mode', 'acceptEdits'];
+      return ['--permission-mode', 'acceptEdits', '--disallowedTools', 'Bash'];
   }
 }
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -243,6 +243,13 @@ describe('permissionArgs', () => {
     assert.ok(!args.some(a => a.includes('bypass') || a.includes('dangerously')));
   });
 
+  test('standard → explicitly disallows Bash rather than relying on acceptEdits semantics', () => {
+    const args = permissionArgs('standard');
+    const idx = args.indexOf('--disallowedTools');
+    assert.ok(idx !== -1);
+    assert.ok(args[idx + 1].split(',').includes('Bash'));
+  });
+
   test('readonly → default mode + allowedTools', () => {
     const args = permissionArgs('readonly');
     assert.ok(args.includes('default'));


### PR DESCRIPTION
## Summary
Standard permission mode's inability to run Bash was an emergent side effect of `acceptEdits` semantics (Bash needs interactive confirmation, which isn't possible in `--print` mode) rather than something BojuBot explicitly enforced. If a future Claude CLI release changes what `acceptEdits` auto-accepts, the orientation text's "cannot: Bash" claim could silently become false with no test coverage to catch it.

## Changes
- `src/ClaudeProcess.ts` — `permissionArgs()` now adds `--disallowedTools Bash` for standard mode, pinning the restriction to our own flag instead of relying on `acceptEdits`'s current default behavior.
- `test/unit.test.ts` — new test asserting standard mode explicitly disallows Bash.
- `CLAUDE.md` — updated the documented CLI args for standard mode.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` (113/113) all pass clean.

## Related issues
Closes #291