### PR TITLE
fix: propagate session rename to chat header and active-session export

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -703,9 +703,7 @@ export class ClaudeView extends ItemView {
     }, () => {
       this.inputEl?.focus();
     }, this.coordinator.sessionFileId, (session) => {
-      if (session.id === this.coordinator.sessionFileId) {
-        this.updateSessionStatus();
-      }
+      this.coordinator.renameActiveSession(session.id, session.title);
     }, (session) => {
       void this.exportSessionToVault(session);
     }, sessionsDir).open();

--- a/src/SessionCoordinator.ts
+++ b/src/SessionCoordinator.ts
@@ -197,6 +197,19 @@ export class SessionCoordinator {
     log('New session placeholder created:', sessionId, cwd ? `cwd=${cwd}` : '');
   }
 
+  /**
+   * Syncs the in-memory title when a session is renamed elsewhere (e.g. the Session
+   * Manager). The header and active-session vault export both read cached coordinator
+   * state, not disk, so without this they'd keep showing the pre-rename title until
+   * the session was reloaded.
+   */
+  renameActiveSession(sessionFileId: string, newTitle: string): void {
+    if (sessionFileId !== this._sessionFileId) return;
+    this._sessionTitle = newTitle;
+    this._hasCustomTitle = true;
+    this.emit('session:updated', { title: newTitle, sessionId: this._sessionId });
+  }
+
   async loadSession(session: StoredSession): Promise<void> {
     this._placeholderSessionId = undefined;
     this._sessionId = session.claudeSessionId || undefined;

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1021,6 +1021,47 @@ function makeTestHost(sessionsDir: string): SessionCoordinatorHost {
   };
 }
 
+describe('SessionCoordinator renameActiveSession', () => {
+  test('updates sessionTitle and fires session:updated when the renamed session is active', () => {
+    const sessionsDir = mkdtempSync(join(tmpdir(), 'bojubot-coord-test-'));
+    try {
+      const coordinator = new SessionCoordinator(makeTestHost(sessionsDir));
+      coordinator.startNewSession();
+      const activeId = coordinator.sessionFileId!;
+
+      const updates: Array<{ title?: string }> = [];
+      coordinator.on('session:updated', (u) => updates.push(u));
+
+      coordinator.renameActiveSession(activeId, 'Renamed Session');
+
+      assert.equal(coordinator.sessionTitle, 'Renamed Session');
+      assert.equal(updates.length, 1);
+      assert.equal(updates[0].title, 'Renamed Session');
+    } finally {
+      try { rmSync(sessionsDir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+    }
+  });
+
+  test('is a no-op when the renamed session is not the active one', () => {
+    const sessionsDir = mkdtempSync(join(tmpdir(), 'bojubot-coord-test-'));
+    try {
+      const coordinator = new SessionCoordinator(makeTestHost(sessionsDir));
+      coordinator.startNewSession();
+      const originalTitle = coordinator.sessionTitle;
+
+      const updates: unknown[] = [];
+      coordinator.on('session:updated', (u) => updates.push(u));
+
+      coordinator.renameActiveSession('some-other-session-id', 'Should Not Apply');
+
+      assert.equal(coordinator.sessionTitle, originalTitle);
+      assert.equal(updates.length, 0);
+    } finally {
+      try { rmSync(sessionsDir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+    }
+  });
+});
+
 describe('SessionCoordinator reentrancy guard', () => {
   test('send() rejects a new turn while one is already in flight, and allows one after it clears', async () => {
     const sessionsDir = mkdtempSync(join(tmpdir(), 'bojubot-coord-test-'));


### PR DESCRIPTION
## Summary
Renaming a session in the Session Manager updated the on-disk `StoredSession` and the modal's own list item, but the chat window header and the active-session vault export both read `SessionCoordinator`'s cached `sessionTitle` — which had no way to be updated from outside the coordinator. Renaming never reached it, so both stayed on the old name until the session was reloaded (matching the workaround described in the issue).

## Changes
- `src/SessionCoordinator.ts` — new `renameActiveSession(sessionFileId, newTitle)` method: syncs `_sessionTitle` when the renamed session is the active one, and marks the title as custom (`_hasCustomTitle = true`) so a later auto-generated title from the first prompt can't clobber a manual rename. Emits `session:updated` so existing listeners pick it up.
- `src/ClaudeView.ts` — Session Manager's `onRename` callback now calls `coordinator.renameActiveSession(...)` instead of directly (and only conditionally) calling `updateSessionStatus()`.
- `test/unit.test.ts` — two new tests: title syncs and `session:updated` fires when the renamed session is active; no-op when it isn't.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` (114/114, 2 new) all pass clean.

## Related issues
Closes #250