### PR TITLE
fix: add open-after-creation checkbox to context file setup dialog

### DIFF
--- a/docs/guide/context-system.md
+++ b/docs/guide/context-system.md
@@ -40,6 +40,8 @@ When you first open BojuBot, a setup dialog offers three options:
 - **Create blank template** — Gives you a pre-structured file with placeholder sections to fill in yourself.
 - **Skip** — Skips setup for now. You can relaunch it any time via **BojuBot: Open context file** from the palette — if the file doesn't exist yet, the setup dialog reopens automatically.
 
+Check **Open context file after creation** in the dialog to have it opened for you as soon as it's ready, whichever of the first two options you pick.
+
 ### What to put in it
 
 ```markdown

--- a/src/ContextGenerationModal.ts
+++ b/src/ContextGenerationModal.ts
@@ -124,6 +124,16 @@ export class ContextGenerationModal extends Modal {
       this.app.workspace.detachLeavesOfType(VIEW_TYPE_CLAUDE);
     }, { capture: true });
 
+    const checkboxRow = contentEl.createDiv({ cls: 'bojubot-checkbox-row' });
+    const openAfterCheckbox = checkboxRow.createEl('input', {
+      attr: { type: 'checkbox', id: 'bojubot-open-context-after' },
+    });
+    openAfterCheckbox.checked = false;
+    checkboxRow.createEl('label', {
+      text: 'Open context file after creation',
+      attr: { for: 'bojubot-open-context-after' },
+    });
+
     const btnRow = contentEl.createDiv({ cls: 'modal-button-container' });
 
     const generateBtn = btnRow.createEl('button', {
@@ -132,17 +142,19 @@ export class ContextGenerationModal extends Modal {
     });
     generateBtn.addEventListener('click', () => {
       this.settled = true;
+      const openAfter = openAfterCheckbox.checked;
       this.close();
       new UserIntroModal(this.app, (intro, contextFiles) => {
-        void this.generateContextFile(intro, contextFiles);
+        void this.generateContextFile(intro, contextFiles, openAfter);
       }).open();
     });
 
     const blankBtn = btnRow.createEl('button', { text: 'Create blank template' });
     blankBtn.addEventListener('click', () => {
       this.settled = true;
+      const openAfter = openAfterCheckbox.checked;
       this.close();
-      void this.createBlankTemplate();
+      void this.createBlankTemplate(openAfter);
     });
 
     const skipBtn = btnRow.createEl('button', { text: 'Skip' });
@@ -189,7 +201,7 @@ export class ContextGenerationModal extends Modal {
     }
   }
 
-  private async generateContextFile(userIntro: string, contextFiles: string[] = []) {
+  private async generateContextFile(userIntro: string, contextFiles: string[] = [], openAfter: boolean = false) {
     log('ContextGenerationModal: spawning background generation');
 
     // Reuse the same session-start context injection every normal session gets
@@ -291,7 +303,12 @@ export class ContextGenerationModal extends Modal {
         if (cancelled) return;
         const exists = this.app.vault.getFileByPath(this.contextFilePath);
         if (exists) {
-          new Notice(`${brandName()}: context file created at "${this.contextFilePath}". Open it in Obsidian to review and edit.`);
+          if (openAfter) {
+            void this.app.workspace.getLeaf(false).openFile(exists);
+            new Notice(`${brandName()}: context file created at "${this.contextFilePath}".`);
+          } else {
+            new Notice(`${brandName()}: context file created at "${this.contextFilePath}". Open it in Obsidian to review and edit.`);
+          }
         } else {
           new Notice(`${brandName()}: generation finished but "${this.contextFilePath}" was not found. You may need to create it manually.`);
         }
@@ -304,7 +321,7 @@ export class ContextGenerationModal extends Modal {
     });
   }
 
-  private async createBlankTemplate() {
+  private async createBlankTemplate(openAfter: boolean) {
     const today = new Date().toISOString().slice(0, 10);
     const stub = [
       '# Vault Context',
@@ -325,8 +342,9 @@ export class ContextGenerationModal extends Modal {
     ].join('\n');
 
     try {
-      await this.app.vault.create(this.contextFilePath, stub);
+      const file = await this.app.vault.create(this.contextFilePath, stub);
       new Notice(`${brandName()}: created blank context file at "${this.contextFilePath}".`);
+      if (openAfter) await this.app.workspace.getLeaf(false).openFile(file);
     } catch (err) {
       log('ContextGenerationModal: failed to create blank template:', err);
       new Notice(`${brandName()}: failed to create context file. Check the debug log.`);

--- a/src/modals/ExportToVaultModal.ts
+++ b/src/modals/ExportToVaultModal.ts
@@ -22,7 +22,7 @@ export class ExportToVaultModal extends Modal {
       attr: { type: 'text', value: this.defaultPath },
     });
 
-    const checkboxRow = contentEl.createDiv({ cls: 'bojubot-export-checkbox-row' });
+    const checkboxRow = contentEl.createDiv({ cls: 'bojubot-checkbox-row' });
     const checkbox = checkboxRow.createEl('input', {
       attr: { type: 'checkbox', id: 'bojubot-open-after' },
     });

--- a/styles.css
+++ b/styles.css
@@ -556,7 +556,7 @@
   margin-bottom: 12px;
 }
 
-.bojubot-export-checkbox-row {
+.bojubot-checkbox-row {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -565,7 +565,7 @@
   color: var(--text-normal);
 }
 
-.bojubot-export-checkbox-row label {
+.bojubot-checkbox-row label {
   cursor: pointer;
   user-select: none;
 }


### PR DESCRIPTION
## Summary
Export-to-vault modals already let you open the resulting note right away; the context file setup dialog (Generate with Claude / blank template) had no equivalent, leaving the user to hunt down and open `_claude-context.md` manually.

## Changes
- `src/ContextGenerationModal.ts` — new "Open context file after creation" checkbox on the setup dialog, threaded through both the Generate-with-Claude and blank-template paths.
- `src/modals/ExportToVaultModal.ts`, `styles.css` — renamed the shared checkbox-row CSS class from export-specific to generic since it's now used in two modals.
- `docs/guide/context-system.md` — documents the new checkbox.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` (115/115) all pass clean.
- [ ] Manual verification — needs a live Obsidian runtime (vault/file creation); not unit-testable.

## Related issues
Closes #132