### PR TITLE
fix: spawn Chat only mode in a neutral temp dir, not the vault root

### DIFF
--- a/docs/guide/permissions.md
+++ b/docs/guide/permissions.md
@@ -21,11 +21,7 @@ The default for new sessions is set in **Settings → BojuBot → Permission mod
 
 Chat only is designed for conversations where you want Claude to reason and suggest, but not touch your vault. Claude can see any context you explicitly hand it — @-mentioned notes, file attachments, clipboard pastes — and can fetch web URLs and search the web. It cannot browse, read, or modify vault files on its own.
 
-The vault folder tree is not injected at session start in this mode, so Claude has no map of your vault structure.
-
-::: info Known limitation
-Claude is spawned with your vault root as its working directory, so it is technically aware of the vault path even in Chat only mode. Obscuring this is tracked as a future improvement.
-:::
+The vault folder tree is not injected at session start in this mode, so Claude has no map of your vault structure. Claude is also spawned in a neutral system temp directory rather than your vault root, so it can't infer or report your vault's file-system path.
 
 ---
 

--- a/src/ClaudeProcess.ts
+++ b/src/ClaudeProcess.ts
@@ -33,6 +33,20 @@ export function permissionArgs(mode: PermissionMode): string[] {
   }
 }
 
+/**
+ * Chat only (restricted) mode has no file-system tools at all, but Claude Code
+ * still spawns with — and is aware of — its OS working directory regardless of
+ * tool access. Spawning it there instead of the vault root keeps the vault's
+ * file-system path from leaking through that awareness (e.g. via error text or
+ * the model's own environment context, independent of anything BojuBot injects).
+ * Called fresh on every spawn (never cached) so a mid-session permission
+ * upgrade takes effect on the very next turn without needing a re-spawn.
+ */
+export function resolveSpawnCwd(mode: PermissionMode, sessionCwd: string | undefined, vaultRoot: string): string {
+  if (mode === 'restricted') return os.tmpdir();
+  return sessionCwd ?? vaultRoot;
+}
+
 // ---------------------------------------------------------------------------
 // Binary detection
 // ---------------------------------------------------------------------------

--- a/src/SessionCoordinator.ts
+++ b/src/SessionCoordinator.ts
@@ -4,6 +4,7 @@ import {
   spawnClaude,
   parseStreamOutput,
   killProcess,
+  resolveSpawnCwd,
   PermissionMode,
   PermissionDenial,
   TokenUsage,
@@ -276,7 +277,7 @@ export class SessionCoordinator {
       proc = spawnClaude({
         binaryPath: binary,
         prompt: '/compact',
-        vaultRoot: this._sessionCwd ?? this.host.getVaultRoot(),
+        vaultRoot: resolveSpawnCwd(this.getEffectivePermissionMode(), this._sessionCwd, this.host.getVaultRoot()),
         env: this.host.getEnv(),
         resumeSessionId: this._sessionId,
         permissionMode: this._permissionOverride ?? this.host.getPermissionMode(),
@@ -319,7 +320,7 @@ export class SessionCoordinator {
       proc = spawnClaude({
         binaryPath: binary,
         prompt,
-        vaultRoot: this._sessionCwd ?? this.host.getVaultRoot(),
+        vaultRoot: resolveSpawnCwd(this.getEffectivePermissionMode(), this._sessionCwd, this.host.getVaultRoot()),
         env: this.host.getEnv(),
         resumeSessionId: this._sessionId,
         permissionMode: this._permissionOverride ?? this.host.getPermissionMode(),

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -19,7 +19,7 @@ import { EventEmitter } from 'node:events';
 
 import { titleFromPrompt, saveSession, saveSessionAtTop, loadAllSessions, deleteSession, loadSessionMessages, getSessionsDir, resolveSessionsDir } from '../src/utils/sessionStorage';
 import { estimateTokens } from '../src/utils/logger';
-import { parseStreamOutput, permissionArgs } from '../src/ClaudeProcess';
+import { parseStreamOutput, permissionArgs, resolveSpawnCwd } from '../src/ClaudeProcess';
 import { extractToolDetail } from '../src/utils/toolFormatting';
 import { extractActions } from '../src/utils/actionParser';
 import { resolveShellEnv } from '../src/utils/shellEnv';
@@ -281,6 +281,31 @@ describe('permissionArgs', () => {
   test('no mode ever includes dangerously-skip-permissions', () => {
     for (const mode of ['standard', 'readonly', 'full', 'restricted'] as const) {
       assert.ok(!permissionArgs(mode).some(a => a.includes('dangerously')));
+    }
+  });
+});
+
+describe('resolveSpawnCwd', () => {
+  test('restricted mode spawns in a neutral temp dir, never the vault root', () => {
+    const cwd = resolveSpawnCwd('restricted', undefined, '/path/to/vault');
+    assert.notEqual(cwd, '/path/to/vault');
+    assert.equal(cwd, tmpdir());
+  });
+
+  test('restricted mode ignores a custom session cwd too — still the neutral temp dir', () => {
+    const cwd = resolveSpawnCwd('restricted', '/path/to/vault/subfolder', '/path/to/vault');
+    assert.equal(cwd, tmpdir());
+  });
+
+  test('standard/readonly/full use the session cwd override when set', () => {
+    for (const mode of ['standard', 'readonly', 'full'] as const) {
+      assert.equal(resolveSpawnCwd(mode, '/custom/cwd', '/path/to/vault'), '/custom/cwd');
+    }
+  });
+
+  test('standard/readonly/full fall back to the vault root with no override', () => {
+    for (const mode of ['standard', 'readonly', 'full'] as const) {
+      assert.equal(resolveSpawnCwd(mode, undefined, '/path/to/vault'), '/path/to/vault');
     }
   });
 });


### PR DESCRIPTION
## Summary
Chat only (restricted) mode has no file-system tools, but Claude Code is still spawned with the vault root as its OS working directory and is aware of it independent of tool access — partially undermining the mode's intent (documented as a known limitation in the permissions guide).

## Changes
- `src/ClaudeProcess.ts` — new pure `resolveSpawnCwd(mode, sessionCwd, vaultRoot)`: returns the OS temp dir when mode is `restricted`, otherwise the existing session-cwd-or-vault-root logic.
- `src/SessionCoordinator.ts` — both `send()` and `compact()` now spawn via `resolveSpawnCwd()`. Resolved fresh on every spawn (not cached), so a mid-session permission upgrade takes effect on the very next turn with no re-spawn logic needed.
- `test/unit.test.ts` — 4 new tests covering restricted vs. other modes, with and without a session cwd override.
- `docs/guide/permissions.md` — removes the now-resolved "Known limitation" callout.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` (119/119, 4 new) all pass clean.

## Related issues
Closes #199