### PR TITLE
chore: match About modal funding card label to Ko-fi branding

### DIFF
--- a/src/modals/AboutModal.ts
+++ b/src/modals/AboutModal.ts
@@ -65,7 +65,7 @@ function buildLinkItems(brand: ResolvedBrand): LinkItem[] {
   if (!isWhiteLabeled(brand)) {
     items.push({
       icon: 'heart',
-      title: 'Buy Me A Coffee',
+      title: 'Buy me a coffee',
       desc: 'Show your love by supporting BojuBot and the author.',
       label: 'Buy',
       href: KOFI_URL,


### PR DESCRIPTION
## Summary
Leftover from the Buy Me a Coffee → Ko-fi funding switch (#309) — the About modal's funding card title still read "Buy Me A Coffee" while linking to KOFI_URL.

## Changes
- `src/modals/AboutModal.ts` — funding card title lowercased to "Buy me a coffee" to match the welcome screen's existing button copy for the same link.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` (115/115) all pass clean.
- [ ] Manual check in the About modal (Scott to verify visually).