### PR TITLE
fix: bring obsidianmd lint + type defs current, fix resulting warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bojubot",
-  "version": "3.3.1",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bojubot",
-      "version": "3.3.1",
+      "version": "3.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.0.0",
@@ -14,7 +14,7 @@
         "@typescript-eslint/parser": "^8.59.0",
         "esbuild": "^0.21.0",
         "eslint-plugin-no-unsanitized": "^4.1.5",
-        "eslint-plugin-obsidianmd": "^0.2.4",
+        "eslint-plugin-obsidianmd": "^0.4.1",
         "obsidian": "latest",
         "tslib": "^2.6.0",
         "tsx": "^4.21.0",
@@ -848,6 +848,36 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
+      "integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "ignore": "^7.0.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -1138,44 +1168,6 @@
       "license": "MIT",
       "dependencies": {
         "ret": "~0.1.10"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@pkgr/core": {
@@ -3168,19 +3160,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -4184,20 +4163,22 @@
       }
     },
     "node_modules/eslint-plugin-obsidianmd": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.2.4.tgz",
-      "integrity": "sha512-5iO3WJ2ZWN4AqBLslS83KsdcEYbT6SiDgRkB9nfM/pM4N87BHBTmScANcSOMiSHDnN1h/vUvWw2scJslVddPVQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz",
+      "integrity": "sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
+        "@eslint/config-helpers": "^0.4.2",
         "@eslint/js": "^9.30.1",
         "@eslint/json": "0.14.0",
         "@microsoft/eslint-plugin-sdl": "^1.1.0",
         "@types/eslint": "9.6.1",
         "@types/node": "20.12.12",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/utils": "8.33.1",
-        "eslint": ">=9.0.0 <10.0.0",
+        "@typescript-eslint/types": "^8.33.1",
+        "@typescript-eslint/utils": "^8.33.1",
+        "eslint": ">=9.19.0",
         "eslint-plugin-depend": "1.3.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-json-schema-validator": "5.1.0",
@@ -4218,7 +4199,7 @@
       "peerDependencies": {
         "@eslint/js": "^9.30.1",
         "@eslint/json": "0.14.0",
-        "eslint": ">=9.0.0 <10.0.0",
+        "eslint": ">=9.19.0",
         "obsidian": "1.8.7",
         "typescript-eslint": "^8.35.1"
       }
@@ -4231,63 +4212,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/project-service": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
-      "integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.33.1",
-        "@typescript-eslint/types": "^8.33.1",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
-      "integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
-      "integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/types": {
@@ -4304,101 +4228,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
-      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
+    "node_modules/eslint-plugin-obsidianmd/node_modules/obsidian": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+      "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.33.1",
-        "@typescript-eslint/tsconfig-utils": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
-      "integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/typescript-estree": "8.33.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
-      "integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.33.1",
-        "eslint-visitor-keys": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "@codemirror/state": "6.5.0",
+        "@codemirror/view": "6.38.6"
       }
     },
     "node_modules/eslint-plugin-obsidianmd/node_modules/typescript": {
@@ -4576,36 +4418,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4637,16 +4449,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4676,19 +4478,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -5376,16 +5165,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/is-number-object": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -5856,16 +5635,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
@@ -5959,33 +5728,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -6227,9 +5969,9 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
-      "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+      "integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6481,27 +6223,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6654,17 +6375,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -6715,30 +6425,6 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -7294,19 +6980,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/toml-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^8.59.0",
     "esbuild": "^0.21.0",
     "eslint-plugin-no-unsanitized": "^4.1.5",
-    "eslint-plugin-obsidianmd": "^0.2.4",
+    "eslint-plugin-obsidianmd": "^0.4.1",
     "obsidian": "latest",
     "tslib": "^2.6.0",
     "tsx": "^4.21.0",

--- a/src/AtMentionController.ts
+++ b/src/AtMentionController.ts
@@ -68,7 +68,7 @@ export class AtMentionController {
   /** Call from textarea 'blur' event. */
   handleBlur(): void {
     // Delay so mousedown on a dropdown item fires before the dropdown hides.
-    activeWindow.setTimeout(() => this.hide(), 150);
+    window.setTimeout(() => this.hide(), 150);
   }
 
   /**

--- a/src/AttachmentHandler.ts
+++ b/src/AttachmentHandler.ts
@@ -74,7 +74,7 @@ export class AttachmentHandler {
   }
 
   openFilePicker(): void {
-    const input = activeDocument.createElement('input');
+    const input = createEl('input');
     input.type = 'file';
     input.onchange = async () => {
       const f = input.files?.[0];

--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -475,7 +475,7 @@ export class ClaudeView extends ItemView {
     });
     this.updatePermissionIcon();
 
-    this.modelIndicatorEl = inputToolbar.createEl('span', { cls: 'bojubot-model-indicator' });
+    this.modelIndicatorEl = inputToolbar.createSpan({ cls: 'bojubot-model-indicator' });
     this.modelIndicatorEl.title = 'Switch model';
     this.modelIndicatorEl.addEventListener('click', () => this.openModelPicker());
     this.updateModelIndicator();
@@ -1339,7 +1339,7 @@ export class ClaudeView extends ItemView {
         item.addEventListener('click', () => void this.loadSession(session));
       });
       if (sessions.length > 3) {
-        const more = recent.createEl('span', { cls: 'bojubot-welcome-recent-more', text: 'More…' });
+        const more = recent.createSpan({ cls: 'bojubot-welcome-recent-more', text: 'More…' });
         more.addEventListener('click', () => void this.showSessionHistory());
       }
     }
@@ -1431,7 +1431,7 @@ export class ClaudeView extends ItemView {
             : 'Still not found. Make sure claude is on your PATH, then restart Obsidian.',
           cls: 'bojubot-setup-error',
         });
-        activeWindow.setTimeout(() => err.remove(), 6000);
+        window.setTimeout(() => err.remove(), 6000);
       }
     });
   }
@@ -1553,7 +1553,7 @@ export class ClaudeView extends ItemView {
     copyBtn.addEventListener('click', () => {
       void navigator.clipboard.writeText(code).then(() => {
         copyBtn.setText('Copied!');
-        activeWindow.setTimeout(() => copyBtn.setText('Copy'), 2000);
+        window.setTimeout(() => copyBtn.setText('Copy'), 2000);
       });
     });
   }
@@ -1575,7 +1575,7 @@ export class ClaudeView extends ItemView {
         this.closeAttachPopover();
       }
     };
-    activeWindow.setTimeout(() => activeDocument.addEventListener('click', this.attachClickOutside), 0);
+    window.setTimeout(() => activeDocument.addEventListener('click', this.attachClickOutside), 0);
   }
 
   private closeAttachPopover() {
@@ -2134,7 +2134,7 @@ class AttachUrlModal extends Modal {
       if (e.key === 'Enter') { const v = input.value.trim(); if (v) { this.onSubmit(v); this.close(); } }
       if (e.key === 'Escape') this.close();
     });
-    activeWindow.setTimeout(() => input.focus(), 50);
+    window.setTimeout(() => input.focus(), 50);
   }
   onClose() { this.contentEl.empty(); }
 }

--- a/src/ContextGenerationModal.ts
+++ b/src/ContextGenerationModal.ts
@@ -55,7 +55,7 @@ class ContextGenerationProgressModal extends Modal {
     if (!this.settled) {
       // Generation is still running and the user tried to dismiss via Escape or
       // clicking outside — reopen immediately rather than letting them proceed.
-      activeWindow.setTimeout(() => this.open(), 0);
+      window.setTimeout(() => this.open(), 0);
     }
   }
 }
@@ -170,7 +170,7 @@ export class ContextGenerationModal extends Modal {
     if (!this.settled) {
       // Easy to fat-finger away via Escape or an outside click before even reading
       // it — reopen instead of silently losing the offer to set up a context file.
-      activeWindow.setTimeout(() => this.open(), 0);
+      window.setTimeout(() => this.open(), 0);
     }
   }
 
@@ -382,11 +382,11 @@ class UserIntroModal extends Modal {
 
     // ── Additional context files (optional) ──────────────────────────────
     const filesSection = contentEl.createDiv({ cls: 'bojubot-intro-files-section' });
-    filesSection.createEl('div', {
+    filesSection.createDiv({
       text: 'Additional context files (optional)',
       cls: 'bojubot-intro-files-label',
     });
-    filesSection.createEl('div', {
+    filesSection.createDiv({
       text: 'Add any files Claude should read before generating — e.g. An existing Claude.md, project notes, or style guides.',
       cls: 'bojubot-intro-files-desc',
     });
@@ -420,7 +420,7 @@ class UserIntroModal extends Modal {
     const cancelBtn = btnRow.createEl('button', { text: 'Cancel' });
     cancelBtn.addEventListener('click', () => this.close());
 
-    activeWindow.setTimeout(() => ta.focus(), 50);
+    window.setTimeout(() => ta.focus(), 50);
   }
 
   private renderChips() {

--- a/src/SlashMenu.ts
+++ b/src/SlashMenu.ts
@@ -67,7 +67,7 @@ export class SlashMenu {
       }
     };
     // Use setTimeout so the click that opened the menu doesn't immediately close it
-    activeWindow.setTimeout(() => activeDocument.addEventListener('mousedown', this.outsideClickHandler), 0);
+    window.setTimeout(() => activeDocument.addEventListener('mousedown', this.outsideClickHandler), 0);
   }
 
   open() {

--- a/src/UIBridge.ts
+++ b/src/UIBridge.ts
@@ -227,7 +227,7 @@ export async function executeAction(app: App, action: BojuBotAction, options: UI
       if (file) {
         const leaf = app.workspace.getLeaf(false);
         await leaf.openFile(file);
-        activeWindow.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
           const view = leaf.view as unknown as { editor?: { getValue(): string; setCursor(pos: { line: number; ch: number }): void } };
           const editor = view?.editor;
           if (editor && action.heading) {

--- a/src/modals/AboutModal.ts
+++ b/src/modals/AboutModal.ts
@@ -97,8 +97,8 @@ export class AboutModal extends Modal {
     const logoImg = header.createEl('img', { cls: 'bojubot-about-logo' });
     logoImg.src = logoSrc;
     logoImg.alt = brand.name;
-    header.createEl('div', { text: brand.name, cls: 'bojubot-about-name' });
-    header.createEl('div', {
+    header.createDiv({ text: brand.name, cls: 'bojubot-about-name' });
+    header.createDiv({
       text: `Version ${this.plugin.manifest.version}`,
       cls: 'bojubot-about-version',
     });
@@ -115,8 +115,8 @@ export class AboutModal extends Modal {
       }
 
       const text = row.createDiv({ cls: 'bojubot-about-item-text' });
-      text.createEl('div', { text: item.title, cls: 'bojubot-about-item-title' });
-      text.createEl('div', { text: item.desc, cls: 'bojubot-about-item-desc' });
+      text.createDiv({ text: item.title, cls: 'bojubot-about-item-title' });
+      text.createDiv({ text: item.desc, cls: 'bojubot-about-item-desc' });
 
       const btn = row.createEl('a', {
         text: item.label,

--- a/src/modals/ExportToVaultModal.ts
+++ b/src/modals/ExportToVaultModal.ts
@@ -46,7 +46,7 @@ export class ExportToVaultModal extends Modal {
       if (e.key === 'Escape') { this.close(); }
     });
 
-    activeWindow.setTimeout(() => { input.focus(); input.select(); }, 50);
+    window.setTimeout(() => { input.focus(); input.select(); }, 50);
   }
 
   onClose() { this.contentEl.empty(); }

--- a/src/modals/PermissionPickerModal.ts
+++ b/src/modals/PermissionPickerModal.ts
@@ -153,7 +153,7 @@ export function openPermissionPopover(
   };
 
   // Defer so the icon's own click event doesn't immediately trigger outsideHandler.
-  activeWindow.setTimeout(() => {
+  window.setTimeout(() => {
     activeDocument.addEventListener('keydown', keyHandler, true);
     activeDocument.addEventListener('mousedown', outsideHandler, true);
   }, 0);

--- a/src/modals/PrimeSessionModal.ts
+++ b/src/modals/PrimeSessionModal.ts
@@ -55,20 +55,20 @@ export class PrimeSessionModal extends Modal {
     {
       const field = form.createDiv({ cls: 'bojubot-param-field' });
       field.createEl('label', { text: 'Session name', cls: 'bojubot-param-label' });
-      field.createEl('div', { text: 'Leave blank to use the first message as title', cls: 'bojubot-param-desc' });
+      field.createDiv({ text: 'Leave blank to use the first message as title', cls: 'bojubot-param-desc' });
       const input = field.createEl('input', {
         cls: 'bojubot-param-input',
         attr: { type: 'text', placeholder: 'E.g. Screenplay review — act 2' },
       });
       input.addEventListener('input', () => { this.name = input.value; });
-      activeWindow.setTimeout(() => input.focus(), 50);
+      window.setTimeout(() => input.focus(), 50);
     }
 
     // ── Working directory ─────────────────────────────────────────────────────
     {
       const field = form.createDiv({ cls: 'bojubot-param-field' });
       field.createEl('label', { text: 'Working directory (cwd)', cls: 'bojubot-param-label' });
-      field.createEl('div', { text: 'Absolute path Claude runs in. Leave blank to use vault root.', cls: 'bojubot-param-desc' });
+      field.createDiv({ text: 'Absolute path Claude runs in. Leave blank to use vault root.', cls: 'bojubot-param-desc' });
       const row = field.createDiv({ cls: 'bojubot-prime-cwd-row' });
       const input = row.createEl('input', {
         cls: 'bojubot-param-input bojubot-prime-cwd-input',
@@ -101,7 +101,7 @@ export class PrimeSessionModal extends Modal {
     {
       const field = form.createDiv({ cls: 'bojubot-param-field' });
       field.createEl('label', { text: 'Initial instructions', cls: 'bojubot-param-label' });
-      field.createEl('div', { text: 'System prompt injected at session start. Leave blank for none.', cls: 'bojubot-param-desc' });
+      field.createDiv({ text: 'System prompt injected at session start. Leave blank for none.', cls: 'bojubot-param-desc' });
       const ta = field.createEl('textarea', {
         cls: 'bojubot-param-textarea',
         attr: { placeholder: 'E.g. You are reviewing screenplay drafts in this folder. Focus on structure and pacing.' },
@@ -116,7 +116,7 @@ export class PrimeSessionModal extends Modal {
       const cb = row.createEl('input', { attr: { type: 'checkbox' } });
       cb.checked = true;
       row.createSpan({ text: 'Include vault context', cls: 'bojubot-param-label bojubot-prime-toggle-label' });
-      field.createEl('div', { text: 'Vault tree, _Claude-context.md, and pinned notes. Uncheck for focused sessions.', cls: 'bojubot-param-desc' });
+      field.createDiv({ text: 'Vault tree, _Claude-context.md, and pinned notes. Uncheck for focused sessions.', cls: 'bojubot-param-desc' });
       cb.addEventListener('change', () => { this.suppressVaultContext = !cb.checked; });
     }
 
@@ -171,7 +171,7 @@ export class PrimeSessionModal extends Modal {
   // ── Attachment helpers ────────────────────────────────────────────────────
 
   private pickFile(): void {
-    const input = activeDocument.createElement('input');
+    const input = createEl('input');
     input.type = 'file';
     input.onchange = async () => {
       const f = input.files?.[0];
@@ -222,7 +222,7 @@ export class PrimeSessionModal extends Modal {
 
     // Insert before the attach list
     if (this.attachListEl) container.insertBefore(row, this.attachListEl);
-    activeWindow.setTimeout(() => input.focus(), 20);
+    window.setTimeout(() => input.focus(), 20);
   }
 
   private renderAttachments(): void {

--- a/src/modals/SessionListModal.ts
+++ b/src/modals/SessionListModal.ts
@@ -145,7 +145,7 @@ export class SessionListModal extends Modal {
     const item = list.createEl('li', { cls });
 
     // Drag handle (hidden while filtering)
-    const grip = item.createEl('span', { cls: 'bojubot-session-drag-handle' });
+    const grip = item.createSpan({ cls: 'bojubot-session-drag-handle' });
     setIcon(grip, 'grip-vertical');
     if (this.isFiltering) grip.addClass('bojubot-invisible');
 
@@ -210,27 +210,27 @@ export class SessionListModal extends Modal {
         this.rerenderList();
       });
     }
-    const titleEl = item.createEl('span', { text: session.title, cls: 'bojubot-session-title' });
-    item.createEl('span', {
+    const titleEl = item.createSpan({ text: session.title, cls: 'bojubot-session-title' });
+    item.createSpan({
       text: new Date(session.updatedAt).toLocaleString(),
       cls: 'bojubot-session-date',
     });
     if (isNew) {
-      item.createEl('span', { text: 'New', cls: 'bojubot-session-new-badge' });
+      item.createSpan({ text: 'New', cls: 'bojubot-session-new-badge' });
     } else if (!resumable) {
-      item.createEl('span', { text: 'Remote', cls: 'bojubot-session-remote-badge' });
+      item.createSpan({ text: 'Remote', cls: 'bojubot-session-remote-badge' });
     }
 
     const tokens = this.sessionTokens.get(session.id);
     if (tokens !== undefined) {
-      const tokensEl = item.createEl('span', {
+      const tokensEl = item.createSpan({
         cls: 'bojubot-session-tokens',
         text: `${formatTokenCount(tokens)} tokens`,
       });
       tokensEl.title = "Estimated tokens in this session's saved message history";
 
       if (this.contextTokens > 0) {
-        const contextEl = item.createEl('span', {
+        const contextEl = item.createSpan({
           cls: 'bojubot-session-tokens-context',
           text: ` (+${formatTokenCount(this.contextTokens)} ctx)`,
         });
@@ -238,7 +238,7 @@ export class SessionListModal extends Modal {
       }
     }
 
-    const actionsDiv = item.createEl('div', { cls: 'bojubot-session-actions' });
+    const actionsDiv = item.createDiv({ cls: 'bojubot-session-actions' });
     const exportBtn = actionsDiv.createEl('button', { cls: 'bojubot-export-btn' });
     setIcon(exportBtn, 'download');
     exportBtn.title = 'Save to vault';

--- a/src/modals/SlashParamModal.ts
+++ b/src/modals/SlashParamModal.ts
@@ -63,7 +63,7 @@ export class SlashParamModal extends Modal {
       const fieldEl = form.createDiv({ cls: 'bojubot-param-field' });
       fieldEl.createEl('label', { text: param.label, cls: 'bojubot-param-label' });
       if (param.description) {
-        fieldEl.createEl('div', { text: param.description, cls: 'bojubot-param-desc' });
+        fieldEl.createDiv({ text: param.description, cls: 'bojubot-param-desc' });
       }
 
       if (param.type === 'input') {
@@ -121,7 +121,7 @@ export class SlashParamModal extends Modal {
         });
       }
 
-      const errEl = fieldEl.createEl('div', { cls: 'bojubot-param-error' });
+      const errEl = fieldEl.createDiv({ cls: 'bojubot-param-error' });
       errEl.hide();
       errorEls[param.id] = errEl;
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -570,8 +570,8 @@ export class BojuBotSettingsTab extends PluginSettingTab {
           });
           const label = row.createEl('label', { cls: 'bojubot-command-name' });
           label.htmlFor = `bojubot-cmd-orphan-${id}`;
-          label.createEl('span', { text: id, cls: 'bojubot-command-orphan-id' });
-          label.createEl('span', { text: ' — not found', cls: 'bojubot-command-orphan-badge' });
+          label.createSpan({ text: id, cls: 'bojubot-command-orphan-id' });
+          label.createSpan({ text: ' — not found', cls: 'bojubot-command-orphan-badge' });
         }
       }
 


### PR DESCRIPTION
## Summary
Your pasted plugin-review notes were flagging warnings from a newer version of Obsidian's own lint tooling than we had pinned. `eslint-plugin-obsidianmd` was 2 minor versions behind (0.2.4 → 0.4.1), and the `obsidian` type-defs package was stuck at 1.12.3 despite `package.json` specifying `"latest"` — just a stale lockfile. Upgraded both, which surfaces the same 46 warnings from the review notes, and fixed everything that's genuinely safe.

## Changes
- **14×** `activeWindow.setTimeout()`/`activeWindow.requestAnimationFrame()` → `window.X()`. Obsidian's rule (auto-fixable) now prefers `window` specifically for timer functions — they don't need binding to the active/focused window the way DOM queries do. `activeDocument.addEventListener` calls right next to several of these are untouched — still correctly need `activeDocument` for popout-window support.
- **~25×** `document.createElement`/`el.createEl('div'|'span', ...)` → the `createDiv()`/`createSpan()` shorthands.
- **2 sites fixed by hand, not via `--fix`:** `eslint --fix`'s own suggested rewrite for `activeDocument.createElement('input')` was `activeWindow.createEl('input')` — that doesn't actually exist (`Window` has no `createEl`; only `HTMLElement`/`DocumentFragment` do, per Obsidian's own type defs). This is a bug in the upstream rule (the `activeDocument` branch hardcodes `canAutofix: true` with no type check). Applying it blindly cascaded into 67 type errors. Fixed with the correct replacement instead: the bare global `createEl('input')`.

## Left alone, deliberately
- `settings.ts`'s `PluginSettingTab` still uses `display()` instead of Obsidian 1.13's new declarative `getSettingDefinitions()` API. That's a full rewrite of an 845-line file, not a lint fix — worth its own design discussion. 6 warnings remain here (1 `prefer-setting-definitions` + 5 `no-deprecated` on `display()`).
- The "unnecessary type assertion" at `brand.ts:112` from the original review notes doesn't reproduce here even with both packages current — left as-is rather than guessing at a fix.

## Test plan
- [x] `npm run build`, `npm run lint` (0 errors, 6 warnings — all from the settings-API migration noted above), `npm test` (126/126) all pass clean.
- [ ] Manual smoke test — this touches DOM-creation code across a dozen UI files (About modal, Session Manager, Prime Session, context setup dialog, attach-file pickers). Diffs are all mechanical/reviewed line-by-line, but worth opening each of those in a live vault to confirm nothing looks off.