### PR TITLE
docs: remove @@BOJU protocol syntax from user-facing docs

### DIFF
--- a/docs/guide/plugin-api.md
+++ b/docs/guide/plugin-api.md
@@ -63,7 +63,7 @@ These fire in order during a Claude turn:
 | `turn:action`       | `(action: BojuBotAction)`      | UI bridge action parsed (excludes `request-permission`)          |
 | `turn:tool-call`    | `(tool, input, toolUseId)`     | Claude initiated a tool call                                     |
 | `turn:tool-result`  | `(toolUseId, content)`         | Tool result received                                             |
-| `turn:query`        | `(query: VaultQuery)`          | A `@@BOJU` query line received                                   |
+| `turn:query`        | `(query: VaultQuery)`          | Claude issued a vault query (backlinks, outlinks, tags, file-list) |
 | `turn:usage`        | `(usage: TokenUsage)`          | Token usage statistics                                           |
 | `turn:stderr`       | `(err: string)`                | stderr output (non-fatal)                                        |
 | `turn:error`        | `(err: string)`                | Fatal process error — no `turn:done` follows                     |

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -96,7 +96,7 @@ Claude treats XML-like tags as semantic containers, so this pattern handles both
 
 This matters most for free-text fields (`input`, `textarea`) where the user might paste in dense or instruction-like text. Use it for any optional parameter, not just the ones that happen to be empty most of the time.
 
-**Keep internal protocol details out of skill bodies.** Skills intended for general use should describe actions in plain language ("open the file in Obsidian") and let Claude's system context handle the mechanics — don't embed UI Bridge trigger syntax (`@@BOJU ...`) directly in a skill prompt body.
+**Keep internal protocol details out of skill bodies.** Skills intended for general use should describe actions in plain language ("open the file in Obsidian") and let Claude's system context handle the mechanics — don't embed raw UI Bridge trigger syntax directly in a skill prompt body.
 
 ## Execution modes
 


### PR DESCRIPTION
## Summary
`@@BOJU` is never something a user types or sees — it's intercepted and stripped before reaching the chat window, emitted autonomously by Claude. Showing the literal wire syntax in the user guide site was an internal implementation detail leaking into docs meant for end users, discoverable only by reading the source.

## Changes
- `docs/guide/plugin-api.md` — describes the `turn:query` event by what triggers it (Claude issuing a vault query) instead of the literal trigger line.
- `docs/guide/skills.md` — keeps the "don't embed protocol syntax in skill bodies" guidance, drops the literal example of what that syntax looks like.

**Left untouched, deliberately:** `src/orientation.md` and `src/references/*.md` are Claude-facing system-prompt content — Claude must see the literal string to know what to emit, so removing it there would break the feature. Internal dev docs (`CLAUDE.md`, `notes/`, `CONTRIBUTING.md`) also untouched — different audience, not end-user product documentation.

## Test plan
- [x] `npm run builddocs` completes clean.
- [x] Confirmed no remaining `@@BOJU` mentions under `docs/guide/` or `docs/index.md`.