### PR TITLE
feat: show current version as a badge above the docs home page hero

### DIFF
--- a/docs/.vitepress/theme/VersionBadge.vue
+++ b/docs/.vitepress/theme/VersionBadge.vue
@@ -1,0 +1,33 @@
+<script setup>
+import manifest from '../../../manifest.json'
+</script>
+
+<template>
+  <a
+    class="version-badge"
+    :href="`https://github.com/ScottKirvan/BojuBot/releases/tag/${manifest.version}`"
+    target="_blank"
+    rel="noopener"
+  >v{{ manifest.version }}</a>
+</template>
+
+<style scoped>
+.version-badge {
+  display: inline-block;
+  margin: 0 0 16px;
+  padding: 4px 14px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 20px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color 0.25s, color 0.25s;
+}
+
+.version-badge:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,4 +1,13 @@
 import DefaultTheme from 'vitepress/theme'
+import { h } from 'vue'
 import './custom.css'
+import VersionBadge from './VersionBadge.vue'
 
-export default DefaultTheme
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'home-hero-before': () => h(VersionBadge),
+    })
+  },
+}


### PR DESCRIPTION
## Summary
Matches the pattern on lucide.dev — a small linked badge reading "vX.Y.Z" positioned above the hero title, rather than buried in the page body.

## Changes
- `docs/.vitepress/theme/VersionBadge.vue` — new component, reads `manifest.json`'s version at build time (Vite JSON import, no runtime fetch), links to that version's GitHub release tag.
- `docs/.vitepress/theme/index.js` — thin custom `Layout` wrapping `DefaultTheme`, injects the badge via VitePress's `home-hero-before` slot.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` (126/126) all pass clean.
- [x] `npm run builddocs` completes clean; confirmed in the built HTML that the badge renders correctly (`v3.5.0`, linked to the release tag) and sits immediately before the `VPHero`/hero `<h1>` in DOM order.