### PR TITLE
fix: revert Standard mode's --disallowedTools Bash (regresses the denial-card flow)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ BojuBot is not limited to features that involve Claude Code directly. Obsidian-n
 - `proc.stdin.end()` closes stdin so claude doesn't hang waiting for more input
 - Flags: `--output-format stream-json --verbose --print` + permission-mode args (see below)
 - Permission modes map to CLI args via `permissionArgs()` in `ClaudeProcess.ts`:
-  - **Standard** (default): `--permission-mode acceptEdits --disallowedTools Bash`
+  - **Standard** (default): `--permission-mode acceptEdits` (Bash denial is emergent from acceptEdits' own behavior in `--print` mode, not independently enforced — see #291)
   - **Read-only**: `--permission-mode default --allowedTools Read,Glob,Grep,WebFetch,WebSearch`
   - **Full**: `--permission-mode bypassPermissions`
   - **Restricted** (planned #154): `--permission-mode default --allowedTools Write,WebFetch,WebSearch` + vault tree injection suppressed

--- a/src/ClaudeProcess.ts
+++ b/src/ClaudeProcess.ts
@@ -29,7 +29,24 @@ export function permissionArgs(mode: PermissionMode): string[] {
       return ['--permission-mode', 'bypassPermissions'];
     case 'standard':
     default:
-      return ['--permission-mode', 'acceptEdits', '--disallowedTools', 'Bash'];
+      // Deliberately NOT `--disallowedTools Bash` — that removes Bash from the
+      // model's tool list entirely, so it can never be attempted, denied, or
+      // logged. Real usage showed that's worse than the plain acceptEdits
+      // behavior below: Claude attempts Bash, the CLI can't get interactive
+      // confirmation in --print mode, denies it, and *that* denial is what
+      // populates permission_denials and drives the denial card (with its
+      // "Allow full access for this session" retry). Confirmed by direct
+      // testing that --disallowedTools silently breaks that whole flow —
+      // no attempt means nothing to deny, so the card never appears and the
+      // user has no signal beyond a plain "not available" text response.
+      //
+      // This does mean "cannot: Bash" in the orientation text is an emergent
+      // consequence of acceptEdits' current behavior, not something BojuBot
+      // enforces directly — if a future Claude Code release changes what
+      // acceptEdits auto-accepts, this could silently drift. Flagging that
+      // here (see #291) rather than "fixing" it, since the fix regressed a
+      // working user-facing flow for a hypothetical future risk.
+      return ['--permission-mode', 'acceptEdits'];
   }
 }
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -270,11 +270,9 @@ describe('permissionArgs', () => {
     assert.ok(!args.some(a => a.includes('bypass') || a.includes('dangerously')));
   });
 
-  test('standard → explicitly disallows Bash rather than relying on acceptEdits semantics', () => {
+  test('standard → does not use --disallowedTools (would remove Bash from the tool list entirely, breaking the deny-and-log flow the denial card depends on)', () => {
     const args = permissionArgs('standard');
-    const idx = args.indexOf('--disallowedTools');
-    assert.ok(idx !== -1);
-    assert.ok(args[idx + 1].split(',').includes('Bash'));
+    assert.ok(!args.includes('--disallowedTools'));
   });
 
   test('readonly → default mode + allowedTools', () => {


### PR DESCRIPTION
## Summary
Reverts the core of #311. Real-world device testing showed `--disallowedTools Bash` (added to close a hypothetical future-fragility concern in #291) actually regressed a working, valuable flow: under plain `acceptEdits`, Claude attempts Bash, the CLI can't get interactive confirmation in `--print` mode, denies it, and that denial is what populates `permission_denials` and drives the denial card (with its "Allow full access for this session" retry option). With Bash removed from the tool list entirely via `--disallowedTools`, there's nothing to attempt or deny — the card never appears, and the user just gets a plain "not available" text response with no recourse but manually switching permission modes.

Confirmed via direct back-and-forth: repeated try-and-fail cycles followed by a working denial card before this change; silent unavailability with no card at all after.

## Changes
- `src/ClaudeProcess.ts` — Standard mode back to plain `--permission-mode acceptEdits`. Added a comment on `permissionArgs()` documenting the tradeoff and the original fragility concern, instead of "fixing" something that wasn't actually broken at the cost of a working UX.
- `test/unit.test.ts` — updated the standard-mode test accordingly.
- `CLAUDE.md` — updated the documented flag.
- Reopened #291 with an explanation.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm test` (126/126) all pass clean.
- [ ] Manual verification — ask Claude to run a shell command in Standard mode; expect the tool-call to show as attempted-then-denied, and the denial card to appear at the end of the turn with an "Allow full access for this session" option.

## Related issues
Reopens #291 (not closing — the underlying fragility concern is still valid as a documented tradeoff, just not something to "fix" this way).