### PR TITLE
fix: match Lucide version badge slot, layout, and styles

### DIFF
--- a/docs/.vitepress/theme/VersionBadge.vue
+++ b/docs/.vitepress/theme/VersionBadge.vue
@@ -3,31 +3,53 @@ import manifest from '../../../manifest.json'
 </script>
 
 <template>
-  <a
-    class="version-badge"
-    :href="`https://github.com/ScottKirvan/BojuBot/releases/tag/${manifest.version}`"
-    target="_blank"
-    rel="noopener"
-  >v{{ manifest.version }}</a>
+  <div class="version-badge-wrap">
+    <a
+      class="version-badge"
+      :href="`https://github.com/ScottKirvan/BojuBot/releases/tag/${manifest.version}`"
+      target="_blank"
+      rel="noopener noreferrer"
+    >v{{ manifest.version }}</a>
+  </div>
 </template>
 
 <style scoped>
+.version-badge-wrap {
+  display: flex;
+  margin-bottom: 16px;
+  justify-content: center;
+}
+
+@media (min-width: 960px) {
+  .version-badge-wrap {
+    justify-content: flex-start;
+  }
+}
+
 .version-badge {
-  display: inline-block;
-  margin: 0 0 16px;
-  padding: 4px 14px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 20px;
-  background: var(--vp-c-bg-soft);
-  color: var(--vp-c-text-2);
-  font-size: 0.8rem;
+  display: block;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background-color: var(--vp-c-bg-alt);
+  color: var(--vp-c-text-1);
+  font-size: 16px;
   font-weight: 600;
+  padding: 2px 12px;
+  white-space: nowrap;
   text-decoration: none;
-  transition: border-color 0.25s, color 0.25s;
+  transition: color 0.25s, border-color 0.25s, background-color 0.25s;
 }
 
 .version-badge:hover {
-  border-color: var(--vp-c-brand-1);
-  color: var(--vp-c-brand-1);
+  border-color: var(--vp-button-alt-hover-border);
+  color: var(--vp-button-alt-hover-text);
+  background-color: var(--vp-button-alt-hover-bg);
+  text-decoration: none;
+}
+
+.version-badge:active {
+  border-color: var(--vp-button-alt-active-border);
+  color: var(--vp-button-alt-active-text);
+  background-color: var(--vp-button-alt-active-bg);
 }
 </style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -7,7 +7,7 @@ export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
-      'home-hero-before': () => h(VersionBadge),
+      'home-hero-info-before': () => h(VersionBadge),
     })
   },
 }


### PR DESCRIPTION
## Summary

Corrects the version badge to match how lucide.dev actually implements theirs.

- **Slot**: `home-hero-before` → `home-hero-info-before` — places the badge inside the hero text area rather than above the entire hero section
- **Layout**: wrapped in a flex `div` with `justify-content: center` on mobile, `flex-start` on desktop (≥960px), matching Lucide's responsive alignment
- **Style corrections** to match Lucide's `Badge.vue`:
  - `border-radius`: `20px` → `6px`
  - `font-size`: `0.8rem` → `16px`
  - `color`: `--vp-c-text-2` → `--vp-c-text-1`
  - `background`: `--vp-c-bg-soft` → `--vp-c-bg-alt`
  - `padding`: `4px 14px` → `2px 12px`
  - Hover/active: `--vp-c-brand-1` → `--vp-button-alt-hover-*` / `--vp-button-alt-active-*` tokens

## Test plan
- [ ] `npm run builddocs` — confirm badge appears inside the hero text block, not above it
- [ ] Check mobile vs desktop alignment (center vs left)
- [ ] Verify hover/active states render correctly in light and dark mode