### PR TITLE
fix: fall back to Sonnet everywhere defaultModel is read, not just at settings init

### DIFF
--- a/src/ClaudeView.ts
+++ b/src/ClaudeView.ts
@@ -21,7 +21,7 @@ import { VaultQuery, VaultQueryResult, resolveQuery, queryLabel, buildInjectMess
 import { BOJU_PREFIX, neutralizeTriggers, KOFI_URL } from './constants';
 import { ContextManager, PERMISSION_DESCRIPTIONS } from './ContextManager';
 import { log, estimateTokens, formatTokenCount } from './utils/logger';
-import { CLAUDE_MODELS, ClaudeModel } from './settings';
+import { CLAUDE_MODELS, ClaudeModel, DEFAULT_MODEL_ID } from './settings';
 import { resolveExportFolder, isWhiteLabeled } from './brand';
 import { extractToolDetail } from './utils/toolFormatting';
 import {
@@ -158,7 +158,7 @@ export class ClaudeView extends ItemView {
       getConfigDir: () => this.app.vault.configDir,
       getEnv: () => this.plugin.shellEnv,
       getPermissionMode: () => this.plugin.settings.permissionMode,
-      getModel: () => this.plugin.settings.defaultModel,
+      getModel: () => this.plugin.settings.defaultModel || DEFAULT_MODEL_ID,
       getSessionsDir: () => this.getSessionsDir(),
       saveLastActiveSessionId: async (id) => {
         this.plugin.settings.lastActiveSessionId = id;
@@ -401,7 +401,7 @@ export class ClaudeView extends ItemView {
           this.app.vault.configDir,
           allModels,
           this.plugin.settings.permissionMode,
-          this.plugin.settings.defaultModel,
+          this.plugin.settings.defaultModel || DEFAULT_MODEL_ID,
           (opts) => this.startNewSession(opts),
         ).open();
       } else {
@@ -1291,7 +1291,7 @@ export class ClaudeView extends ItemView {
     headerLogo.draggable = false;
     header.createSpan({ cls: 'bojubot-welcome-header-name', text: brandName });
     header.createSpan({ cls: 'bojubot-welcome-version', text: `v${this.plugin.manifest.version}` });
-    const activeModel = CLAUDE_MODELS.find(m => m.id === this.plugin.settings.defaultModel);
+    const activeModel = CLAUDE_MODELS.find(m => m.id === (this.plugin.settings.defaultModel || DEFAULT_MODEL_ID));
     if (activeModel) {
       header.createSpan({ cls: 'bojubot-welcome-model', text: activeModel.displayName });
     }
@@ -1977,7 +1977,7 @@ export class ClaudeView extends ItemView {
 
   private updateModelIndicator() {
     if (!this.modelIndicatorEl) return;
-    const effectiveModel = this.coordinator.sessionModel || this.plugin.settings.defaultModel;
+    const effectiveModel = this.coordinator.sessionModel || this.plugin.settings.defaultModel || DEFAULT_MODEL_ID;
     const active = CLAUDE_MODELS.find(m => m.id === effectiveModel);
     this.modelIndicatorEl.setText(active?.displayName ?? 'Claude Sonnet');
   }
@@ -1990,7 +1990,7 @@ export class ClaudeView extends ItemView {
     );
     const allModels = [...CLAUDE_MODELS, ...loadCustomModels(customModelsPath)];
 
-    new ModelPickerModal(this.app, this.plugin.settings.defaultModel, allModels, (model) => {
+    new ModelPickerModal(this.app, this.plugin.settings.defaultModel || DEFAULT_MODEL_ID, allModels, (model) => {
       const previous = this.plugin.settings.defaultModel;
       this.plugin.settings.defaultModel = model.id;
       void this.plugin.saveSettings().then(() => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,11 @@ export const CLAUDE_MODELS: ClaudeModel[] = [
   { id: 'claude-fable-5', displayName: 'Claude Fable 5', description: 'Most capable — coding-focused, highest reasoning' },
 ];
 
+/** Falls back to this when settings.defaultModel is unset — covers both fresh
+ *  installs and installs with an empty string already persisted from before
+ *  this default existed (DEFAULT_SETTINGS alone only helps fresh installs). */
+export const DEFAULT_MODEL_ID = 'claude-sonnet-4-6';
+
 export interface BojuBotSettings {
   binaryPath: string;
   contextFilePath: string;
@@ -125,7 +130,7 @@ export const DEFAULT_SETTINGS: BojuBotSettings = {
   contextFileSizeCapTokens: 0,
   minimalMode: false,
   userLabel: '',
-  defaultModel: 'claude-sonnet-4-6',
+  defaultModel: DEFAULT_MODEL_ID,
   sessionCreationCount: 0,
   hideSponsorshipMessages: false,
 };


### PR DESCRIPTION
## Summary

Follow-up to #334 — that PR set `DEFAULT_SETTINGS.defaultModel` to `claude-sonnet-4-6`, but that only helps brand-new installs. Anyone with a `settings.json` already on disk (like a live test vault) has `''` persisted from before this default existed, and that persisted value keeps overriding the new default on every load.

Since no model entry matches an empty string, every consumer of `settings.defaultModel` silently fell back to whatever happened to be first in `CLAUDE_MODELS` — Haiku — instead of Sonnet: the Custom Session model dropdown, the toolbar model picker/indicator, the welcome screen, and the `--model` flag passed to `spawnClaude`.

## Type of Change
- [x] Bug fix (non-breaking, fixes an issue)

## Details

Added `DEFAULT_MODEL_ID` (`claude-sonnet-4-6`) in `settings.ts` and applied it as an `|| ` fallback at every read site in `ClaudeView.ts`:
- `SessionCoordinatorHost.getModel()`
- The Custom Session modal's `defaultModel` argument
- The welcome screen's active-model label
- `updateModelIndicator()`'s effective model
- `ModelPickerModal`'s current-selection highlight

## Testing

**Steps to verify:**
1. With an existing settings.json that has `defaultModel: ""` (i.e. don't touch the model picker after updating), Shift+click **+** to open the session setup dialog.
2. Confirm the Model field shows "Claude Sonnet 4.6" selected, not "Claude Haiku 4.5".
3. Confirm the toolbar's model indicator also reads "Claude Sonnet 4.6".

**Expected result:** Sonnet is the effective default everywhere, for both fresh and pre-existing installs, until the user explicitly picks a different model.

**Test environment:**
- OS: Windows 11
- App/plugin version: 3.5.0
- Any other relevant context: `npm run build`, `npm run lint` (0 errors, only pre-existing settings-API warnings), and `npm test` (130/130 passing) all pass clean.

## Checklist
- [x] Self-reviewed the diff
- [x] Tested the change locally
- [x] Updated documentation if behavior changed
- [x] No new warnings or errors introduced
