### PR TITLE
feat: add manual preview-release-notes workflow

### DIFF
--- a/.github/workflows/preview-release-notes.yml
+++ b/.github/workflows/preview-release-notes.yml
@@ -1,0 +1,30 @@
+name: Manual — Preview Release Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Anticipated next version tag (e.g. v3.6.0) — need not exist yet
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  models: read
+
+jobs:
+  preview:
+    uses: ScottKirvan/.github/.github/workflows/reusable-preview-release-notes.yml@main
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      project_name: "BojuBot"
+      project_context: "BojuBot is an Obsidian plugin. More than a writing assistant — BojuBot turns your Obsidian vault into a personal AI platform using Claude Code."
+      header: |
+        ## 👾 BojuBot for Obsidian 👾
+
+        More than a writing assistant — BojuBot turns your Obsidian vault into a personal AI platform using Claude Code
+
+        🫶❤️[Support this project](https://ko-fi.com/ScottKirvan) · 📖 [User Guide](https://www.scottkirvan.com/BojuBot/) · 💬 [Discord](https://discord.gg/TN6XJSNK5Y) · 🐛 [Report a Bug](https://github.com/ScottKirvan/BojuBot/issues/new?template=bug_report.md) · ✨ [Request Feature](https://github.com/ScottKirvan/BojuBot/issues/new?template=feature_request.md) · 📋 [Changelog](https://github.com/ScottKirvan/BojuBot/blob/main/notes/CHANGELOG.md)
+
+      changelog_path: ""
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` caller for the new shared `reusable-preview-release-notes.yml` workflow.

**To use:**
1. Merge ScottKirvan/.github#24 first (the shared workflow)
2. Go to Actions → **Manual — Preview Release Notes**
3. Enter the anticipated next version tag (e.g. `v3.6.0`)
4. Once complete, find the draft pre-release on the [Releases page](https://github.com/ScottKirvan/BojuBot/releases) and review the AI-generated notes
5. Delete the draft when done — release-please will create the real release later

Re-running with the same tag updates the draft in place.

## Test plan
- [ ] Depends on ScottKirvan/.github#24 merging first
- [ ] Trigger from Actions tab with an anticipated tag
- [ ] Confirm draft appears on releases page with AI-generated notes
- [ ] Confirm deleting the draft has no side effects on the release-please flow