### PR TITLE
fix: reframe project_context toward everyday users with per-audience rule

### DIFF
--- a/.github/workflows/preview-release-notes.yml
+++ b/.github/workflows/preview-release-notes.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       tag_name: ${{ inputs.tag_name }}
       project_name: "BojuBot"
-      project_context: "BojuBot is an Obsidian plugin. More than a writing assistant — BojuBot turns your Obsidian vault into a personal AI platform using Claude Code."
+      project_context: "BojuBot is an Obsidian plugin that brings AI conversation directly into a personal notes vault. Most users are writers, researchers, and everyday thinkers who want help brainstorming, editing prose, and working through ideas — the plugin handles the technical complexity so they can focus on their work. Some changes target power users, developers, or anyone customizing or distributing BojuBot; when a change is clearly for that audience, write the explanation in terms of what they specifically gain."
       header: |
         ## 👾 BojuBot for Obsidian 👾
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       project_name: "BojuBot"
-      project_context: "BojuBot is an Obsidian plugin. More than a writing assistant — BojuBot turns your Obsidian vault into a personal AI platform using Claude Code."
+      project_context: "BojuBot is an Obsidian plugin that brings AI conversation directly into a personal notes vault. Most users are writers, researchers, and everyday thinkers who want help brainstorming, editing prose, and working through ideas — the plugin handles the technical complexity so they can focus on their work. Some changes target power users, developers, or anyone customizing or distributing BojuBot; when a change is clearly for that audience, write the explanation in terms of what they specifically gain."
       header: |
         ## 👾 BojuBot for Obsidian 👾
 


### PR DESCRIPTION
## Summary
- Updates `project_context` in both `release.yml` and `preview-release-notes.yml`
- Replaces the terse "AI platform" description with one that centers writers, researchers, and everyday thinkers as the primary audience
- Adds an inline instruction for the AI to shift framing for features that specifically target power users, developers, or team deployers — so those bullets speak to the right audience without forcing a new fixed section

## Why
The old context ("BojuBot turns your Obsidian vault into a personal AI platform using Claude Code") reads as developer/AI-bro marketing copy. Most actual users are people who want help thinking and writing, not people who want to configure an AI platform. The new context reflects that while still giving the AI permission to correctly frame power-user features (e.g., white-labeling, branding) for their actual audience.

## Test plan
- [ ] Merge .github#27 first (updated reusable workflow with anti-tautology rule)
- [ ] Run the preview workflow for an upcoming BojuBot release
- [ ] Verify release notes read as user-facing outcomes, not developer changelog entries
- [ ] Check that any power-user-targeted bullets still land correctly